### PR TITLE
Added specs for RST-721

### DIFF
--- a/spec/features/partner_status_spec.rb
+++ b/spec/features/partner_status_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+# This feature represents the acceptance criteria defined in RST-721
+RSpec.describe 'Partner Status Test', type: :feature, js: true do
+  # Feature: Partner Status
+  #
+  # Ability for citizen to confirm their Partner status
+  #
+  #
+  # Personas:
+  #
+  #   JOHN is a single, 56 year old man with 1 child. He is not on any benefit. He has £2,990 worth of capital and an income of £1,330. He has a court fee of £600
+  #   ALLI is a married, 60 year old man with 1 child. He is not on any benefit. He has £3,800 worth of capital and an income of £1,489. He has a court fee of £1,334
+  #
+  #
+  # Scenario: JOHN confirms he is single
+  # Given I am John
+  # And I am on the Partner Status page
+  # And I select Single option
+  # When I click Next Step
+  # Then I should see the next page
+  let(:next_page) { Calculator::Test::En::CourtFeePage.new }
+  scenario 'John confirms he is single' do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to_marital_status_question
+
+    # Act
+    marital_status_page.marital_status.set(messaging.t('hwf_pages.marital_status.labels.marital_status.single'))
+    marital_status_page.next
+
+    # Assert
+    expect(next_page).to be_displayed
+  end
+
+  #
+  # Scenario: ALLI confirms he is married
+  # Given I am Alli and partner
+  # And I am on the Partner Status page
+  # And I select Married or living with someone option
+  # When I click Next Step
+  # Then I should see the next page
+  #
+  scenario 'Alli confirms he is married' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to_marital_status_question
+
+    # Act
+    marital_status_page.marital_status.set(messaging.t('hwf_pages.marital_status.labels.marital_status.sharing_income'))
+    marital_status_page.next
+
+    # Assert
+    expect(next_page).to be_displayed
+  end
+end

--- a/test_common/helpers/setup.rb
+++ b/test_common/helpers/setup.rb
@@ -8,10 +8,14 @@ module Calculator
       end
 
       def answer_questions_up_to_disposable_capital
-        start_calculator_session
+        answer_up_to_marital_status_question
         answer_marital_status_question
         answer_court_fee_question
         answer_date_of_birth_question
+      end
+
+      def answer_up_to_marital_status_question
+        start_calculator_session
       end
 
       def answer_questions_up_to_total_income

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -34,6 +34,11 @@ en:
           heading: You should be eligible for a Partial Remission
           detail: As you and your partner have stated you have a combined monthly income %{total_income}, you would need to contribute %{contribution} of your stated %{fee} fee or would receive a partial refund of %{remission} if you have paid the full fee within the last 3 months
   hwf_pages:
+    marital_status:
+      labels:
+        marital_status:
+          single: Single
+          sharing_income: Married or living with someone
     income_benefits:
       errors:
         nothing_selected: 'Please select from the list'

--- a/test_common/page_objects/en/calculator/court_fee_page.rb
+++ b/test_common/page_objects/en/calculator/court_fee_page.rb
@@ -2,6 +2,7 @@ module Calculator
   module Test
     module En
       class CourtFeePage < BasePage
+        set_url '/calculation/fee'
         section :fee, ::Calculator::Test::QuestionNumericSection, :calculator_question, 'How much is the court or tribunal fee you have to pay (or have paid within the last 3 months)?'
         element :next_button, :button, 'Next step'
 


### PR DESCRIPTION
This PR adds the tests to prove already added functionality for RST-721
This functionality was added simply to allow the user to progress through to the disposabe capital test (which was developed first).
Saying that, the functionality is extremely simple - allowing the data through and that is it - no validation or anything