### PR TITLE
Feature/rst 722 dev

### DIFF
--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -1,5 +1,4 @@
 div.calculator.marital_status
-  h1 How much help with fees will I receive?
   = form_for form, as: :calculation, url: calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_marital_status.html.slim
+++ b/app/views/calculation/_marital_status.html.slim
@@ -7,19 +7,24 @@ div.calculator.marital_status
       fieldset
         legend = t('calculation.field_labels.marital_status')
 
-        details
-          summary = 'Click to reveal more information'
+        details data-behavior="question_help"
+          summary data-behavior="toggle"= 'Help with Status'
 
-          .panel-indent
+          .panel-indent data-behavior="question_help_text"
             .text
-              h2.heading-small = 'heading small'
+              h2.heading-small = 'Single means you rely on your own income, single also means:'
               ul.list.list-bullet
-                li = 'item_1'
-
-              h2.heading-small = 'heading 2 small'
+                li = 'you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)'
+                li = 'you are changing your legal gender'
+                li = 'you are experiencing domestic violence'
+                li = 'you are experiencing forced marriage'
+              h2.heading-small = 'Married or living with someone and sharing an income means:'
               ul.list.list-bullet
-                li = 'item_1'
-
+                li = 'married'
+                li = 'civil partners'
+                li = 'living together as if you are married or in a civil partnership'
+                li = 'living at the same address with a joint income'
+                li = 'part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care'
         label.block-label
           = f.radio_button :marital_status, 'single'
           = 'Single'

--- a/app/views/calculation/_marital_status.html.slim
+++ b/app/views/calculation/_marital_status.html.slim
@@ -1,5 +1,4 @@
 div.calculator.marital_status
-  h1 How much help with fees will I receive?
   = form_for form, as: :calculation, url: calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('error' if form.errors.any?)
       - if true
@@ -8,23 +7,18 @@ div.calculator.marital_status
         legend = t('calculation.field_labels.marital_status')
 
         details data-behavior="question_help"
-          summary data-behavior="toggle"= 'Help with Status'
+          summary data-behavior="toggle"= t('calculation.guidance.marital_status.summary')
 
           .panel-indent data-behavior="question_help_text"
             .text
-              h2.heading-small = 'Single means you rely on your own income, single also means:'
+              h2.heading-small = t('calculation.guidance.marital_status.detail.single.summary')
               ul.list.list-bullet
-                li = 'you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)'
-                li = 'you are changing your legal gender'
-                li = 'you are experiencing domestic violence'
-                li = 'you are experiencing forced marriage'
-              h2.heading-small = 'Married or living with someone and sharing an income means:'
+                - t('calculation.guidance.marital_status.detail.single.text').lines.each do |line|
+                  li = line
+              h2.heading-small = t('calculation.guidance.marital_status.detail.sharing_income.summary')
               ul.list.list-bullet
-                li = 'married'
-                li = 'civil partners'
-                li = 'living together as if you are married or in a civil partnership'
-                li = 'living at the same address with a joint income'
-                li = 'part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care'
+                - t('calculation.guidance.marital_status.detail.sharing_income.text').lines.each do |line|
+                  li = line
         label.block-label
           = f.radio_button :marital_status, 'single'
           = 'Single'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,6 +12,6 @@
       strong.phase-tag Alpha
       span This is a new service – your <a href="#">feedback</a> will help us to improve it.
   .content-header
-    h1 How much help with fees will I receive?
+    h1 data-behavior="heading" = t('calculation.common.page_header')
   = yield
 = render template: "layouts/govuk_template"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,3 +129,24 @@ en:
         guidance: ''
     common:
       page_header: "Find out if you can get help with fees"
+    guidance:
+      marital_status:
+        summary: "Help with Status"
+        detail:
+          single:
+            summary: "Single means you rely on your own income, single also means:"
+            text: |
+              you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)
+              you are changing your legal gender
+              you are experiencing domestic violence
+              you are experiencing forced marriage
+          sharing_income:
+            summary: "Married or living with someone and sharing an income means:"
+            text: |
+              married
+              civil partners
+              living together as if you are married or in a civil partnership
+              living at the same address with a joint income
+              part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+            
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,3 +127,5 @@ en:
       scottish_legal_aid:
         label: "Scottish Legal Aid (Civil Claims)"
         guidance: ''
+    common:
+      page_header: "Find out if you can get help with fees"

--- a/spec/features/view_partner_status_content_spec.rb
+++ b/spec/features/view_partner_status_content_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+# This feature represents the acceptance criteria defined in RST-675
+RSpec.describe 'Partner status content', type: :feature, js: true do
+  # Feature:
+  #
+  # Partner Status Content
+  #
+  #
+  # Scenario: View Partner Status Heading and Question
+  #
+  #               Given I am on the Partner Status page
+  #
+  #               When I view the Heading, Partner status question on the page
+  #
+  #               Then Heading should read "Find out if you can get help with fees"
+  #
+  #               And Partner Status question reads "Are you single, married or living with someone and sharing income"
+  scenario 'View Partner Status Heading and Question' do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to_marital_status_question
+
+    # Assert
+    aggregate_failures 'validating content of header and question' do
+      expect(marital_status_page.heading).to be_present
+      expect(marital_status_page.marital_status).to be_present
+    end
+  end
+  #
+  #
+  #
+  # Scenario: View Guidance Information
+  #
+  #               Given I am on the Partner Status page
+  #
+  #               When I click on "Help with Status" link
+  #
+  #               Then Guidance Information is displayed directly below the Help with status link
+  #
+  #
+  scenario 'View Guidance Information' do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to_marital_status_question
+    marital_status_page.toggle_guidance
+
+    # Assert
+    expect(marital_status_page.validate_guidance).to be true
+  end
+
+  # Scenario: Hide Guidance Information
+  #
+  #               Given I am on the Partner Status page
+  #
+  #               And Guidance Information is displayed
+  #
+  #               When I click on the "Help with Status" link
+  #
+  #               Then Guidance Information is hidden
+  #
+  scenario 'View Guidance Information' do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to_marital_status_question
+    marital_status_page.toggle_guidance
+    marital_status_page.wait_for_guidance
+
+    # Act
+    marital_status_page.toggle_guidance
+    marital_status_page.wait_until_guidance_invisible
+
+    # Assert
+    expect(marital_status_page).to have_no_guidance
+  end
+
+  #
+  # Guidance Information Content:
+  #
+  # Single means you rely on your own income, single also means:
+  #
+  # you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)
+  # you are changing your legal gender
+  # you are experiencing domestic violence
+  # you are experiencing forced marriage
+  # Married or living with someone and sharing an income means:
+  #
+  # married
+  # civil partners
+  # living together as if you are married or in a civil partnership
+  # living at the same address with a joint income
+  # part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+  #
+  #
+  # Partner Status Page Heading:
+  #
+  # Find out if you can get help with fees
+  #
+  #
+  # Page Question:
+  #
+  # Are you single, or any of: married or living with someone and sharing an income
+end

--- a/spec/features/view_partner_status_content_spec.rb
+++ b/spec/features/view_partner_status_content_spec.rb
@@ -1,6 +1,33 @@
 require 'rails_helper'
 # This feature represents the acceptance criteria defined in RST-675
 RSpec.describe 'Partner status content', type: :feature, js: true do
+  #
+  # Guidance Information Content:
+  #
+  # Single means you rely on your own income, single also means:
+  #
+  # you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)
+  # you are changing your legal gender
+  # you are experiencing domestic violence
+  # you are experiencing forced marriage
+  # Married or living with someone and sharing an income means:
+  #
+  # married
+  # civil partners
+  # living together as if you are married or in a civil partnership
+  # living at the same address with a joint income
+  # part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+  #
+  #
+  # Partner Status Page Heading:
+  #
+  # Find out if you can get help with fees
+  #
+  #
+  # Page Question:
+  #
+  # Are you single, or any of: married or living with someone and sharing an income
+
   # Feature:
   #
   # Partner Status Content
@@ -62,7 +89,7 @@ RSpec.describe 'Partner status content', type: :feature, js: true do
   #
   #               Then Guidance Information is hidden
   #
-  scenario 'View Guidance Information' do
+  scenario 'Hide Guidance Information' do
     # Arrange
     given_i_am(:john)
     answer_up_to_marital_status_question
@@ -71,36 +98,8 @@ RSpec.describe 'Partner status content', type: :feature, js: true do
 
     # Act
     marital_status_page.toggle_guidance
-    marital_status_page.wait_until_guidance_invisible
 
     # Assert
     expect(marital_status_page).to have_no_guidance
   end
-
-  #
-  # Guidance Information Content:
-  #
-  # Single means you rely on your own income, single also means:
-  #
-  # you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)
-  # you are changing your legal gender
-  # you are experiencing domestic violence
-  # you are experiencing forced marriage
-  # Married or living with someone and sharing an income means:
-  #
-  # married
-  # civil partners
-  # living together as if you are married or in a civil partnership
-  # living at the same address with a joint income
-  # part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
-  #
-  #
-  # Partner Status Page Heading:
-  #
-  # Find out if you can get help with fees
-  #
-  #
-  # Page Question:
-  #
-  # Are you single, or any of: married or living with someone and sharing an income
 end

--- a/test_common/capybara_selectors/exact_heading_text.rb
+++ b/test_common/capybara_selectors/exact_heading_text.rb
@@ -1,0 +1,7 @@
+Capybara.add_selector(:exact_heading_text) do
+  xpath do |locator, _options|
+    XPath.generate do |x|
+      x.descendant(:h1)[x.attr(:'data-behavior').is('heading') & x.string.n.is(locator)]
+    end
+  end
+end

--- a/test_common/capybara_selectors/help_section_labelled.rb
+++ b/test_common/capybara_selectors/help_section_labelled.rb
@@ -1,7 +1,8 @@
 Capybara.add_selector(:help_section_labelled) do
   xpath do |locator, _options|
     XPath.generate do |x|
-      x.descendant(:details)[x.attr(:'data-behavior').is('question_help') & x.descendant(:summary)[x.string.n.is(locator)]]
+      x.descendant(:details)[x.attr(:'data-behavior').is('question_help') &
+                             x.descendant(:summary)[x.string.n.is(locator)]]
     end
   end
 end

--- a/test_common/capybara_selectors/help_section_labelled.rb
+++ b/test_common/capybara_selectors/help_section_labelled.rb
@@ -1,0 +1,7 @@
+Capybara.add_selector(:help_section_labelled) do
+  xpath do |locator, _options|
+    XPath.generate do |x|
+      x.descendant(:details)[x.attr(:'data-behavior').is('question_help') & x.descendant(:summary)[x.string.n.is(locator)]]
+    end
+  end
+end

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -57,6 +57,22 @@ en:
         marital_status:
           single: Single
           sharing_income: Married or living with someone
+      guidance:
+        marital_status:
+          text: |
+            Single means you rely on your own income, single also means:
+            you are going through divorce, or your marriage is dissolved or annulled (unless you have married again or live with a new partner)
+            you are changing your legal gender
+            you are experiencing domestic violence
+            you are experiencing forced marriage
+            Married or living with someone and sharing an income means:
+            married
+            civil partners
+            living together as if you are married or in a civil partnership
+            living at the same address with a joint income
+            part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+
+
     fee:
       errors:
         non_numeric: Please enter numeric value with no decimal places

--- a/test_common/page_objects/en/calculator/marital_status_page.rb
+++ b/test_common/page_objects/en/calculator/marital_status_page.rb
@@ -28,12 +28,10 @@ module Calculator
           marital_status.has_no_help_text?
         end
 
+        # Waits for the guidance to be visible
+        # @raise [Capybara::ExpectationNotMet] if the guidance never became visible in the allowed timeout
         def wait_for_guidance
           marital_status.wait_for_help_text
-        end
-
-        def wait_until_guidance_invisible
-          marital_status.wait_until_help_text_invisible
         end
       end
     end

--- a/test_common/page_objects/en/calculator/marital_status_page.rb
+++ b/test_common/page_objects/en/calculator/marital_status_page.rb
@@ -3,12 +3,37 @@ module Calculator
     module En
       class MaritalStatusPage < BasePage
         set_url '/calculation/marital_status'
-        section :marital_status, ::Calculator::Test::QuestionRadioListSection, :calculator_question, 'Are you single, married or living with someone and sharing an income?'
+        element :heading, :exact_heading_text, 'Find out if you can get help with fees'
+        section :marital_status, ::Calculator::Test::MaritalStatusQuestionSection, :calculator_question, 'Are you single, married or living with someone and sharing an income?'
         element :next_button, :button, 'Next step'
 
         # Progress to the next page
         def next
           next_button.click
+        end
+
+        # Toggles the guidance text for this question
+        def toggle_guidance
+          marital_status.toggle_help
+        end
+
+        # Validates that the guidance text is correct for the english language
+        # @raise [Capybara::ExpectationNotMet] if the text wasn't found in the correct place
+        def validate_guidance
+          marital_status.validate_guidance(messaging.t('hwf_pages.marital_status.guidance.marital_status.text'))
+        end
+
+        # Indicates if the marital status field has no guidance text visible
+        def has_no_guidance?
+          marital_status.has_no_help_text?
+        end
+
+        def wait_for_guidance
+          marital_status.wait_for_help_text
+        end
+
+        def wait_until_guidance_invisible
+          marital_status.wait_until_help_text_invisible
         end
       end
     end

--- a/test_common/sections/marital_status_question.rb
+++ b/test_common/sections/marital_status_question.rb
@@ -1,0 +1,34 @@
+require_relative 'question_radio_list'
+require_relative 'question_help'
+module Calculator
+  module Test
+    class MaritalStatusQuestionSection < QuestionRadioListSection
+      section :help_section, QuestionHelpSection, :help_section_labelled, 'Help with Status'
+
+      # Validates that the guidance text is as expected
+      # @param [String, Array[String]] text_or_array Either a single string to (partially) match or an array of strings which
+      #   will be joined by a CR.  Note that whitespace should not be important, nor html structure etc..
+      # @raise [Capybara::ExpectationNotMet] if the assertion hasn't succeeded during wait time
+      def validate_guidance(text_or_array)
+        strings = Array(text_or_array)
+        help_section.assert_text(strings.join("\n"))
+      end
+
+      def toggle_help
+        help_section.toggle
+      end
+
+      def has_no_help_text?
+        help_section.has_no_help_text?
+      end
+
+      def wait_for_help_text
+        help_section.wait_for_help_text
+      end
+
+      def wait_until_help_text_invisible
+        help_section.wait_until_help_text_invisible
+      end
+    end
+  end
+end

--- a/test_common/sections/marital_status_question.rb
+++ b/test_common/sections/marital_status_question.rb
@@ -6,8 +6,9 @@ module Calculator
       section :help_section, QuestionHelpSection, :help_section_labelled, 'Help with Status'
 
       # Validates that the guidance text is as expected
-      # @param [String, Array[String]] text_or_array Either a single string to (partially) match or an array of strings which
-      #   will be joined by a CR.  Note that whitespace should not be important, nor html structure etc..
+      # @param [String, Array[String]] text_or_array Either a single string to (partially) match or an
+      #  array of strings which will be joined by a CR.  Note that whitespace should not be important,
+      # nor html structure etc..
       # @raise [Capybara::ExpectationNotMet] if the assertion hasn't succeeded during wait time
       def validate_guidance(text_or_array)
         strings = Array(text_or_array)
@@ -18,17 +19,19 @@ module Calculator
         help_section.toggle
       end
 
+      # rubocop:disable Style/PredicateName
       def has_no_help_text?
-        help_section.has_no_help_text?
+        help_section.help_text_collapsed?
       end
 
-      def wait_for_help_text
-        help_section.wait_for_help_text
+      def has_help_text?
+        help_section.help_text_expanded?
       end
+      # rubocop:enable Style/PredicateName
 
-      def wait_until_help_text_invisible
-        help_section.wait_until_help_text_invisible
-      end
+      delegate :wait_for_help_text, to: :help_section
+
+      delegate :wait_for_no_help_text, to: :help_section
     end
   end
 end

--- a/test_common/sections/question_help.rb
+++ b/test_common/sections/question_help.rb
@@ -1,0 +1,11 @@
+module Calculator
+  module Test
+    class QuestionHelpSection < BaseSection
+      element :toggle_node, '[data-behavior=toggle]'
+      element :help_text, '[data-behavior=question_help_text]'
+      def toggle
+        toggle_node.click
+      end
+    end
+  end
+end

--- a/test_common/sections/question_help.rb
+++ b/test_common/sections/question_help.rb
@@ -3,8 +3,28 @@ module Calculator
     class QuestionHelpSection < BaseSection
       element :toggle_node, '[data-behavior=toggle]'
       element :help_text, '[data-behavior=question_help_text]'
+      element :expanded_root, :xpath, (XPath.generate { |x| x.self[x.attr(:open)] })
+      element :collapsed_root, :xpath, './self::*[not(@open)]'
+
+      # Toggles help text
       def toggle
         toggle_node.click
+      end
+
+      # Indicates if the help text is collapsed, if not waits for it.  If it
+      # has not collapsed by the standard timeout, returns false
+      #
+      # @return [Boolean] Indicates if collapsed
+      def help_text_collapsed?
+        has_collapsed_root?
+      end
+
+      # Indicates if the help text is expanded, if not waits for it.  If it
+      # has not expanded by the standard timeout, returns false
+      #
+      # @return [Boolean] Indicates if collapsed
+      def help_text_expanded?
+        has_expanded_root?
       end
     end
   end

--- a/test_common/sections/question_radio_list.rb
+++ b/test_common/sections/question_radio_list.rb
@@ -1,6 +1,6 @@
 module Calculator
   module Test
-    class QuestionRadioListSection < BaseSection
+    class QuestionRadioListSection < QuestionSection
       def set(value)
         choose(value)
       end


### PR DESCRIPTION
This PR implements RST-722 - which validates the (english) content of the marital status page.
Note that this is the first spec which proves the guidance text - and that it expands and collapses, so there has been a bit of refactoring in the page objects and sections to allow this to be easily tested