### PR TITLE
Feature/rst 803 dev

### DIFF
--- a/app/controllers/calculation_controller.rb
+++ b/app/controllers/calculation_controller.rb
@@ -67,11 +67,11 @@ class CalculationController < ApplicationController
   def calculation_params
     params.require(:calculation).permit :marital_status,
       :fee,
-      :date_of_birth,
-      :partner_date_of_birth,
       :disposable_capital,
       :number_of_children,
       :total_income,
+      date_of_birth: [:day, :month, :year],
+      partner_date_of_birth: [:day, :month, :year],
       benefits_received: []
   end
 end

--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -1,14 +1,14 @@
 require 'blank_date'
 require 'invalid_date'
 # A form object for the date of birth question
-# Allows for date's being represented using rails '1i, 2i and 3i' notation.
+# Allows for date's being represented using a hash for each (with keys day, month and year)
 class DateOfBirthForm < BaseForm
   # @!attribute [rw] date_of_birth
   #   @return [Date] The date of birth of the individual or the main person in a couple
-  attribute :date_of_birth, :date
+  attribute :date_of_birth, :strict_date
   # @!attribute [rw] partner_date_of_birth
   #   @return [Date,nil] The date of birth of the partner in a couple
-  attribute :partner_date_of_birth, :date
+  attribute :partner_date_of_birth, :strict_date
 
   validates :date_of_birth,
     presence: true,
@@ -33,52 +33,7 @@ class DateOfBirthForm < BaseForm
     :date_of_birth
   end
 
-  def initialize(inputs = {})
-    super convert_date_input(inputs)
-  end
-
   private
-
-  # @TODO This method is responsibe for converting from rails's 1i, 2i, 3i format for dates
-  # - this may well get changed but not focusing on this right now
-  # @TODO Definitely move this into an active model type
-  def convert_date_input(data)
-    inputs = data.dup
-    convert_date_of_birth(inputs)
-    convert_partner_date_of_birth(inputs)
-    inputs
-  end
-
-  def convert_date_of_birth(inputs)
-    return if inputs[:date_of_birth].is_a?(Date)
-    inputs[:date_of_birth] = convert_rails_date(inputs: inputs, attribute: :date_of_birth)
-  end
-
-  def convert_partner_date_of_birth(inputs)
-    return if inputs[:partner_date_of_birth].is_a?(Date)
-    inputs[:partner_date_of_birth] = convert_rails_date(inputs: inputs, attribute: :partner_date_of_birth)
-  end
-
-  def convert_rails_date(inputs:, attribute:)
-    year = inputs.delete("#{attribute}(1i)")
-    month = inputs.delete("#{attribute}(2i)")
-    day = inputs.delete("#{attribute}(3i)")
-    if [year, month, day].all?(&:nil?)
-      nil
-    elsif [year, month, day].any?(&:blank?)
-      BlankDate.new
-    else
-      create_date year, month, day
-    end
-  end
-
-  def create_date(year, month, day)
-    # This might look odd - its a way to convert string to integer, raising an error if it cannot be converted
-    # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
-    Date.new Float(year).to_i, Float(month).to_i, Float(day).to_i
-  rescue ArgumentError
-    InvalidDate.new year, month, day
-  end
 
   def export_params
     {

--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -12,11 +12,11 @@ class DateOfBirthForm < BaseForm
 
   validates :date_of_birth,
     presence: true,
-    date: true,
+    strict_date: true,
     age: { greater_than_or_equal_to: 16, allow_nil: true, allow_blank: true, if: :date_of_birth_valid? }
   validates :partner_date_of_birth,
     presence: true,
-    date: true,
+    strict_date: true,
     age: {
       greater_than_or_equal_to: 16,
       allow_nil: true,

--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -73,7 +73,9 @@ class DateOfBirthForm < BaseForm
   end
 
   def create_date(year, month, day)
-    Date.new year.to_i, month.to_i, day.to_i
+    # This might look odd - its a way to convert string to integer, raising an error if it cannot be converted
+    # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
+    Date.new Float(year).to_i, Float(month).to_i, Float(day).to_i
   rescue ArgumentError
     InvalidDate.new year, month, day
   end

--- a/app/services/benefits_received_calculator_service.rb
+++ b/app/services/benefits_received_calculator_service.rb
@@ -34,6 +34,7 @@ class BenefitsReceivedCalculatorService < BaseCalculatorService
 
   def mark_as_help_available
     self.available_help = :full
+    self.final_decision = true
     messages << { key: :likely, source: :disposable_capital }
   end
 end

--- a/app/services/calculation_service.rb
+++ b/app/services/calculation_service.rb
@@ -47,7 +47,7 @@ class CalculationService
     'BenefitsReceived',
     'HouseholdIncome'
   ].freeze
-  attr_reader :messages, :inputs, :calculations, :available_help, :remission, :final_decision_by
+  attr_reader :messages, :inputs, :available_help, :remission, :final_decision_by
 
   # Create an instance of CalculationService
   # @param [Hash] inputs
@@ -61,7 +61,6 @@ class CalculationService
     self.remission = 0.0
     self.messages = []
     self.calculators = calculators
-    self.calculations = {}
   end
 
   # Performs the calculation with the given inputs and configured calculators
@@ -86,7 +85,7 @@ class CalculationService
     catch(:abort) do
       calculators.each do |calculator|
         my_result = catch(:invalid_inputs) do
-          calculations[calculator.identifier] = perform_calculation_using(calculator)
+          perform_calculation_using(calculator)
         end
         throw :abort, self if my_result.final_decision? || !my_result.valid?
       end
@@ -118,7 +117,7 @@ class CalculationService
   def fields_required
     @fields_required ||= begin
       required = calculators.map do |c|
-        c.fields_required(inputs, previous_calculations: calculations_summary)
+        c.fields_required(inputs)
       end.flatten
       my_fields_required + required
     end
@@ -154,12 +153,6 @@ class CalculationService
     MY_FIELDS - inputs.keys
   end
 
-  def calculations_summary
-    calculations.map do |k, v|
-      [k, { available_help: v.available_help }]
-    end.to_h
-  end
-
   def perform_calculation_using(calculator)
     result = calculator.call(inputs)
     if result.available_help == :none
@@ -188,5 +181,5 @@ class CalculationService
   end
 
   attr_accessor :calculators
-  attr_writer :messages, :inputs, :calculations, :available_help, :remission, :final_decision_by
+  attr_writer :messages, :inputs, :available_help, :remission, :final_decision_by
 end

--- a/app/services/household_income_calculator_service.rb
+++ b/app/services/household_income_calculator_service.rb
@@ -23,13 +23,8 @@ class HouseholdIncomeCalculatorService < BaseCalculatorService
     self
   end
 
-  # @TODO Review the method below - see details in RST-733, but allow for now
-  def self.fields_required(inputs, previous_calculations:)
-    if previous_calculations.dig(:benefits_received, :available_help) == :full
-      []
-    else
-      MY_FIELDS - inputs.keys
-    end
+  def self.fields_required(inputs)
+    MY_FIELDS - inputs.keys
   end
 
   private

--- a/app/types/strict_date_type.rb
+++ b/app/types/strict_date_type.rb
@@ -39,7 +39,7 @@ class StrictDateType < ActiveModel::Type::Value
     # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
     Date.new Float(value[:year]).to_i, Float(value[:month]).to_i, Float(value[:day]).to_i
   rescue ArgumentError
-    invalid_date_class.new year, month, day
+    invalid_date_class.new value[:year], value[:month], value[:day]
   end
 
   def self.value_nil?(value)
@@ -49,6 +49,8 @@ class StrictDateType < ActiveModel::Type::Value
   def self.value_blank?(value)
     value.slice(:day, :month, :year).values.any?(&:blank?)
   end
+
+  private_class_method :value_nil?, :value_blank?
 
   attr_accessor :invalid_date_class, :blank_date_class
 end

--- a/app/types/strict_date_type.rb
+++ b/app/types/strict_date_type.rb
@@ -35,22 +35,29 @@ class StrictDateType < ActiveModel::Type::Value
   end
 
   def create_date(value)
-    # This might look odd - its a way to convert string to integer, raising an error if it cannot be converted
-    # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
-    Date.new Float(value[:year]).to_i, Float(value[:month]).to_i, Float(value[:day]).to_i
+    self.class.date_from_hash(value)
   rescue ArgumentError
     invalid_date_class.new value[:year], value[:month], value[:day]
   end
 
-  def self.value_nil?(value)
-    [value[:year], value[:month], value[:day]].all?(&:nil?)
-  end
+  class << self
+    private
 
-  def self.value_blank?(value)
-    value.slice(:day, :month, :year).values.any?(&:blank?)
-  end
+    def date_from_hash(value)
+      # This might look odd - its a way to convert string to integer, raising an error if it cannot be converted
+      # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
+      Date.new Float(value[:year]).to_i, Float(value[:month]).to_i, Float(value[:day]).to_i
+    end
 
-  private_class_method :value_nil?, :value_blank?
+    def value_nil?(value)
+      [value[:year], value[:month], value[:day]].all?(&:nil?)
+    end
+
+    def value_blank?(value)
+      value.slice(:day, :month, :year).values.any?(&:blank?)
+    end
+
+  end
 
   attr_accessor :invalid_date_class, :blank_date_class
 end

--- a/app/types/strict_date_type.rb
+++ b/app/types/strict_date_type.rb
@@ -1,0 +1,49 @@
+require 'blank_date'
+require 'invalid_date'
+# The strict date does not take any rubbish.  It does not convert strings into year zero
+# for example.  So, allows for much better validation.
+# It can also return an @see InvalidDate instance or a @see BlankDate instance if the date is either blank
+# or invalid.  This is then used by the custom validators.
+# This means that any code using the value can rely on it being a date or nil.
+# Any code that needs to display the invalid values can still call 'day', 'month' or 'year' on it etc..
+class StrictDateType < ActiveModel::Type::Value
+  def initialize(invalid_date_class: InvalidDate, blank_date_class: BlankDate, **args)
+    self.invalid_date_class = invalid_date_class
+    self.blank_date_class = blank_date_class
+    super(*args)
+  end
+
+  # Casts the value to a date
+  # @param [Object] value The value to cast to a date or nil
+  # @return [Date,Nil,InvalidDate,BlankDate] The cast date or nil if nil was given
+  def cast(value)
+    if value.nil? || value.is_a?(Date)
+      value
+    else
+      raise "The strict date type must be presented with a hash containing day, month and year" unless value.is_a?(Hash)
+      cast_value(value.symbolize_keys)
+    end
+  end
+
+  private
+
+  def cast_value(value)
+    if [value[:year], value[:month], value[:day]].all?(&:nil?)
+      nil
+    elsif value.slice(:day, :month, :year).values.any?(&:blank?)
+      blank_date_class.new
+    else
+      create_date value[:year], value[:month], value[:day]
+    end
+  end
+
+  def create_date(year, month, day)
+    # This might look odd - its a way to convert string to integer, raising an error if it cannot be converted
+    # as to_i returns 0 if it fails to convert to Integer('09') fails because it things its octal
+    Date.new Float(year).to_i, Float(month).to_i, Float(day).to_i
+  rescue ArgumentError
+    invalid_date_class.new year, month, day
+  end
+
+  attr_accessor :invalid_date_class, :blank_date_class
+end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,0 +1,32 @@
+require 'invalid_date'
+# This validator will fail if the date provided is an 'InvalidDate' - or whichever invalid date class
+# is passed into its config.
+# This allows the form object to store an 'InvalidDate' which contains the original values passed by the user
+# which keeps it happy as it is still a 'Date' - just an invalid one.
+#
+# @example Simple Usage
+#
+#   validates :date_of_birth, date: true
+#
+# @example With custom invalid date class
+#
+#   validates :date_of_birth, date: { invalid_date_class: CustomInvalidDate }
+#
+# Note that at present, the invalid dates are not given out by anything but the individual form objects themselves
+# however, these will be moved into custom date types so all form objects can have this stuff.
+# @TODO Review the comment above
+class DateValidator < ActiveModel::EachValidator
+  def initialize(invalid_date_class: InvalidDate, **args)
+    self.invalid_date_class = invalid_date_class
+    super(args)
+  end
+
+  def validate_each(record, attribute, value)
+    return if value.nil? || value.blank?
+    record.errors.add(attribute, :invalid_date) if value.is_a?(invalid_date_class)
+  end
+
+  private
+
+  attr_accessor :invalid_date_class
+end

--- a/app/validators/strict_date_validator.rb
+++ b/app/validators/strict_date_validator.rb
@@ -13,7 +13,6 @@ require 'invalid_date'
 #   validates :date_of_birth, date: { invalid_date_class: CustomInvalidDate }
 #
 # The custom active model type 'strict_date' is responsible for returning these special types
-# @TODO Review the comment above
 class StrictDateValidator < ActiveModel::EachValidator
   def initialize(invalid_date_class: InvalidDate, **args)
     self.invalid_date_class = invalid_date_class

--- a/app/validators/strict_date_validator.rb
+++ b/app/validators/strict_date_validator.rb
@@ -12,10 +12,9 @@ require 'invalid_date'
 #
 #   validates :date_of_birth, date: { invalid_date_class: CustomInvalidDate }
 #
-# Note that at present, the invalid dates are not given out by anything but the individual form objects themselves
-# however, these will be moved into custom date types so all form objects can have this stuff.
+# The custom active model type 'strict_date' is responsible for returning these special types
 # @TODO Review the comment above
-class DateValidator < ActiveModel::EachValidator
+class StrictDateValidator < ActiveModel::EachValidator
   def initialize(invalid_date_class: InvalidDate, **args)
     self.invalid_date_class = invalid_date_class
     super(args)

--- a/app/views/calculation/_benefits_received.html.slim
+++ b/app/views/calculation/_benefits_received.html.slim
@@ -1,14 +1,5 @@
 .content-body.benefits_received
-  .feedback data-behavior="calculator_feedback"
-    - if current_calculation.available_help == :none
-      div.negative
-        h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_not_get_help')
-        p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)
-    - if current_calculation.available_help == :full
-      div.positive
-        h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_get_help')
-        p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)
-
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_benefits_received.html.slim
+++ b/app/views/calculation/_benefits_received.html.slim
@@ -5,11 +5,6 @@
       fieldset
         legend
           h2.heading-medium = I18n.t('calculation.field_labels.benefits_received')
-        - if form.errors.include?(:benefits_received)
-          span.error-message = form.errors[:benefits_received].join(', ')
-        label
-          = gds_error_messages(model: f.object, method: :benefits_received)
-          = gds_multiple_choices_with_guidance(form: f, method: :benefits_received, choices: form.benefits.map {|benefit| [benefit, t("calculation.benefits.#{benefit}.label"), t("calculation.benefits.#{benefit}.guidance", raise: false)]})
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.income_benefits.summary')
           .panel-indent data-behavior="question_help_text"
@@ -18,6 +13,11 @@
               ul.list.list-bullet
                 - t('calculation.guidance.income_benefits.detail.text').lines.each do |line|
                   li = line
+        - if form.errors.include?(:benefits_received)
+          span.error-message = form.errors[:benefits_received].join(', ')
+        label
+          = gds_error_messages(model: f.object, method: :benefits_received)
+          = gds_multiple_choices_with_guidance(form: f, method: :benefits_received, choices: form.benefits.map {|benefit| [benefit, t("calculation.benefits.#{benefit}.label"), t("calculation.benefits.#{benefit}.guidance", raise: false)]})
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_date_of_birth.html.slim
+++ b/app/views/calculation/_date_of_birth.html.slim
@@ -11,16 +11,16 @@
         .form-date
           .form-group
             label.block-label
-              = f.label :'date_of_birth(3i)', 'Day'
-              = f.text_field :'date_of_birth(3i)', value: f.object.date_of_birth.try(:day), class: 'form-control'
+              = f.label :'date_of_birth[day]', 'Day'
+              = f.text_field :'date_of_birth[day]', value: f.object.date_of_birth.try(:day), class: 'form-control'
           .form-group
             label.block-label
-              = f.label :'date_of_birth(2i)', 'Month'
-              = f.text_field :'date_of_birth(2i)', value: f.object.date_of_birth.try(:month), class: 'form-control'
+              = f.label :'date_of_birth[month]', 'Month'
+              = f.text_field :'date_of_birth[month]', value: f.object.date_of_birth.try(:month), class: 'form-control'
           .form-group
             label.block-label
-              = f.label :'date_of_birth(1i)', 'Year'
-              = f.text_field :'date_of_birth(1i)', value: f.object.date_of_birth.try(:year), class: 'form-control'
+              = f.label :'date_of_birth[year]', 'Year'
+              = f.text_field :'date_of_birth[year]', value: f.object.date_of_birth.try(:year), class: 'form-control'
     - if current_calculation.inputs[:marital_status] == 'sharing_income'
       .form-group class=('form-group-error' if form.errors.any?)
         fieldset.inline
@@ -32,16 +32,16 @@
           .form-date
             .form-group
               label.block-label
-                = f.label :'partner_date_of_birth(3i)', 'Day'
-                = f.text_field :'partner_date_of_birth(3i)', value: f.object.partner_date_of_birth.try(:day), class: 'form-control'
+                = f.label :'partner_date_of_birth[day]', 'Day'
+                = f.text_field :'partner_date_of_birth[day]', value: f.object.partner_date_of_birth.try(:day), class: 'form-control'
             .form-group
               label.block-label
-                = f.label :'partner_date_of_birth(2i)', 'Month'
-                = f.text_field :'partner_date_of_birth(2i)', value: f.object.partner_date_of_birth.try(:month), class: 'form-control'
+                = f.label :'partner_date_of_birth[month]', 'Month'
+                = f.text_field :'partner_date_of_birth[month]', value: f.object.partner_date_of_birth.try(:month), class: 'form-control'
             .form-group
               label.block-label
-                = f.label :'partner_date_of_birth(1i)', 'Year'
-                = f.text_field :'partner_date_of_birth(1i)', value: f.object.partner_date_of_birth.try(:year), class: 'form-control'
+                = f.label :'partner_date_of_birth[year]', 'Year'
+                = f.text_field :'partner_date_of_birth[year]', value: f.object.partner_date_of_birth.try(:year), class: 'form-control'
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_date_of_birth.html.slim
+++ b/app/views/calculation/_date_of_birth.html.slim
@@ -1,4 +1,5 @@
 .content-body.date_of_birth
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset.inline

--- a/app/views/calculation/_disposable_capital.html.slim
+++ b/app/views/calculation/_disposable_capital.html.slim
@@ -5,11 +5,6 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.disposable_capital')
-
-        - if form.errors.include?(:disposable_capital)
-          span.error-message = form.errors[:disposable_capital].join(', ')
-        label.block-label
-          = f.text_field :disposable_capital, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.disposable_capital.summary')
 
@@ -23,6 +18,10 @@
               ul.list.list-bullet
                 - t('calculation.guidance.disposable_capital.detail.exclude.text').lines.each do |line|
                   li = line
+        - if form.errors.include?(:disposable_capital)
+          span.error-message = form.errors[:disposable_capital].join(', ')
+        label.block-label
+          = f.text_field :disposable_capital, class: 'form-control'
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_disposable_capital.html.slim
+++ b/app/views/calculation/_disposable_capital.html.slim
@@ -1,4 +1,5 @@
 .content-body.disposable_capital
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -4,17 +4,16 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.fee')
+        - if form.errors.include?(:fee)
+          span.error-message = form.errors[:fee].join(', ')
+        label.block-label
+          = f.text_field :fee, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle" = t('calculation.guidance.fee.summary')
 
           .panel-indent data-behavior="question_help_text"
             .text
               h2.heading-small = t('calculation.guidance.fee.detail_text')
-        - if form.errors.include?(:fee)
-          span.error-message = form.errors[:fee].join(', ')
-        label.block-label
-          = f.text_field :fee, class: 'form-control'
-
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -1,4 +1,5 @@
 .content-body.fee
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -5,16 +5,16 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.fee')
-        - if form.errors.include?(:fee)
-          span.error-message = form.errors[:fee].join(', ')
-        label.block-label
-          = f.text_field :fee, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle" = t('calculation.guidance.fee.summary')
 
           .panel-indent data-behavior="question_help_text"
             .text
               h2.heading-small = t('calculation.guidance.fee.detail_text')
+        - if form.errors.include?(:fee)
+          span.error-message = form.errors[:fee].join(', ')
+        label.block-label
+          = f.text_field :fee, class: 'form-control'
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_feedback.html.slim
+++ b/app/views/calculation/_feedback.html.slim
@@ -1,0 +1,9 @@
+.feedback data-behavior="calculator_feedback"
+  - if current_calculation.available_help == :none
+    div.negative
+      h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_not_get_help')
+      p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)
+  - if current_calculation.available_help == :full
+    div.positive
+      h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_get_help')
+      p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)

--- a/app/views/calculation/_marital_status.html.slim
+++ b/app/views/calculation/_marital_status.html.slim
@@ -6,14 +6,6 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.marital_status')
-        - if form.errors.include?(:marital_status)
-          span.error-message = form.errors[:marital_status].join(', ')
-        .multiple-choice
-          = f.radio_button :marital_status, 'single'
-          = f.label :marital_status_single, 'Single', allow_method_names_outside_object: true
-        .multiple-choice
-          = f.radio_button :marital_status, 'sharing_income'
-          = f.label :marital_status_sharing_income, 'Married or living with someone', allow_method_names_outside_object: true
         details data-behavior="question_help"
           summary data-behavior="toggle" = t('calculation.guidance.marital_status.summary')
 
@@ -27,6 +19,14 @@
               ul.list.list-bullet
                 - t('calculation.guidance.marital_status.detail.sharing_income.text').lines.each do |line|
                   li = line
+        - if form.errors.include?(:marital_status)
+          span.error-message = form.errors[:marital_status].join(', ')
+        .multiple-choice
+          = f.radio_button :marital_status, 'single'
+          = f.label :marital_status_single, 'Single', allow_method_names_outside_object: true
+        .multiple-choice
+          = f.radio_button :marital_status, 'sharing_income'
+          = f.label :marital_status_sharing_income, 'Married or living with someone', allow_method_names_outside_object: true
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_marital_status.html.slim
+++ b/app/views/calculation/_marital_status.html.slim
@@ -1,4 +1,5 @@
 .content-body.marital_status
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     = f.hidden_field :ensure_not_blank, allow_method_names_outside_object: true, value: '1'
     .form-group class=('form-group-error' if form.errors.any?)

--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -1,14 +1,5 @@
 .content-body.number_of_children
-  .feedback data-behavior="calculator_feedback"
-    - if current_calculation.available_help == :none
-      div.negative
-        h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_not_get_help')
-        p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)
-    - if current_calculation.available_help == :full
-      div.positive
-        h2 data-behavior="calculator_feedback_header" = t('calculation.feedback.should_get_help')
-        p data-behavior="calculator_feedback_message" = calculator_feedback_for(current_calculation)
-
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -14,7 +14,10 @@
       fieldset
         legend
           h2.heading-medium = 'How many children live with you or are you responsible for supporting financially?'
-
+        - if form.errors.include?(:number_of_children)
+          span.error-message = form.errors[:number_of_children].join(', ')
+        label.block-label
+          = f.text_field :number_of_children, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.number_of_children.summary')
 
@@ -24,10 +27,6 @@
               ul.list.list-bullet
                 - t('calculation.guidance.number_of_children.detail.text').lines.each do |line|
                   li = line
-        label.block-label
-          = f.text_field :number_of_children, class: 'form-control'
-        - if form.errors.include?(:number_of_children)
-          span.error-message = form.errors[:number_of_children].join(', ')
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -5,10 +5,6 @@
       fieldset
         legend
           h2.heading-medium = 'How many children live with you or are you responsible for supporting financially?'
-        - if form.errors.include?(:number_of_children)
-          span.error-message = form.errors[:number_of_children].join(', ')
-        label.block-label
-          = f.text_field :number_of_children, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.number_of_children.summary')
 
@@ -18,6 +14,10 @@
               ul.list.list-bullet
                 - t('calculation.guidance.number_of_children.detail.text').lines.each do |line|
                   li = line
+        - if form.errors.include?(:number_of_children)
+          span.error-message = form.errors[:number_of_children].join(', ')
+        label.block-label
+          = f.text_field :number_of_children, class: 'form-control'
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/app/views/calculation/_total_income.html.slim
+++ b/app/views/calculation/_total_income.html.slim
@@ -1,5 +1,5 @@
 .content-body.total_income
-  h1 How much help with fees will I receive?
+  = render partial: 'feedback', locals: { current_calculation: current_calculation }
   = form_for form, as: :calculation, url: update_calculation_url(form: form.type), method: :patch do |f|
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset

--- a/app/views/calculation/_total_income.html.slim
+++ b/app/views/calculation/_total_income.html.slim
@@ -5,12 +5,6 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.total_income')
-
-        - if form.errors.include?(:total_income)
-          span.error-message = form.errors[:total_income].join(', ')
-        span.form-hint = t('calculation.hints.total_income')
-        label.block-label
-          = f.text_field :total_income, class: 'form-control'
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.total_income.summary')
 
@@ -20,6 +14,11 @@
               ul.list.list-bullet
                 - t('calculation.guidance.total_income.detail.text').lines.each do |line|
                   li = line
+        - if form.errors.include?(:total_income)
+          span.error-message = form.errors[:total_income].join(', ')
+        span.form-hint = t('calculation.hints.total_income')
+        label.block-label
+          = f.text_field :total_income, class: 'form-control'
     .form-group
       = f.submit 'Next step', class: 'button'
   = render partial: 'previous_questions', locals: { current_calculation: current_calculation, disabled: false } unless current_calculation.inputs.empty?

--- a/config/initializers/active_model_types.rb
+++ b/config/initializers/active_model_types.rb
@@ -1,2 +1,3 @@
 ActiveModel::Type.register(:array, ArrayType)
 ActiveModel::Type.register(:strict_integer, StrictIntegerType)
+ActiveModel::Type.register(:strict_date, StrictDateType)

--- a/config/initializers/disable_error_wrapping.rb
+++ b/config/initializers/disable_error_wrapping.rb
@@ -1,1 +1,1 @@
-ActionView::Base.field_error_proc = Proc.new { |html_tag, instance| html_tag }
+ActionView::Base.field_error_proc = proc { |html_tag, _instance| html_tag }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@ en:
   activemodel:
     errors:
       models:
+        marital_status_form:
+          attributes:
+            marital_status:
+              inclusion: "Select whether you're single, married or living with someone and sharing an income"
         benefits_received_form:
           attributes:
             benefits_received:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
             partner_date_of_birth:
               blank: Please enter a valid date of birth
               age_less_than: You and your partner must be over %{count} years old to apply for help with fees
+              invalid_date: Please enter a valid date of birth
         number_of_children_form:
           attributes:
             number_of_children:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
             date_of_birth:
               blank: Please enter a valid date of birth
               age_less_than: You must be over %{count} years old to apply for help with fees
+              invalid_date: Please enter a valid date of birth
             partner_date_of_birth:
               blank: Please enter a valid date of birth
               age_less_than: You and your partner must be over %{count} years old to apply for help with fees

--- a/lib/invalid_date.rb
+++ b/lib/invalid_date.rb
@@ -1,0 +1,30 @@
+# As our form objects convert to the correct type on input, rather than use the typical
+# mess of fetching values before validation that active record does, we will take the
+# approach of having an invalid date which is simply an instance of Date whose valid?
+# method returns false and the day, month and year values are whatever is provided
+class InvalidDate < Date
+  attr_reader :day, :month, :year
+  def self.new(year, month, day)
+    super(1970, 1, 1).tap do |instance|
+      instance.send(:initialize, year, month, day)
+    end
+  end
+
+  def initialize(year, month, day)
+    self.day = day
+    self.month = month
+    self.year = year
+  end
+
+  def blank?
+    false
+  end
+
+  def valid?
+    false
+  end
+
+  private
+
+  attr_writer :day, :month, :year
+end

--- a/spec/features/income_related_benefits_spec.rb
+++ b/spec/features/income_related_benefits_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Income Benefit Page Content', type: :feature, js: true do
   # When I click on the Next step button
   # Then I should see that I am eligible for a full remission
   #  And income benefit question, selected answer appended to the Previous answers section
-  scenario 'Select income related benefit option' do
+  scenario 'Select income related benefit option - ensuring full remission' do
     # Arrange - Take oliver to the benefits page
     given_i_am(:oliver)
     answer_up_to(:benefits)

--- a/spec/features/validate_date_of_birth_spec.rb
+++ b/spec/features/validate_date_of_birth_spec.rb
@@ -185,7 +185,20 @@ RSpec.describe 'Validate date of birth Test', type: :feature, js: true do
   # The following scenarios had no acceptance criteria from the business - but are important still
   scenario 'Citizen is single and puts non numerics in the day field' do
     # Arrange
-    given_i_am(:veronica)
+    given_i_am(:john)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('day/07/1970')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is single and puts non numerics in the month field' do
+    # Arrange
+    given_i_am(:john)
     answer_up_to(:date_of_birth)
 
     # Act
@@ -193,14 +206,97 @@ RSpec.describe 'Validate date of birth Test', type: :feature, js: true do
     date_of_birth_page.next
 
     # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is single and puts non numerics in the year field' do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('01/07/someyear')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is married and puts non numerics in their own day field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('aa/07/1970')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is married and puts non numerics in their own month field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('09/July/1970')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is married and puts non numerics in their own year field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('09/08/someyear')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is married and puts non numerics in their partners day field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.partner_date_of_birth.set('aa/07/1970')
+    date_of_birth_page.next
+
+    # Assert
     expect(date_of_birth_page.partner_date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
   end
-  scenario 'Citizen is single and puts non numerics in the month field'
-  scenario 'Citizen is single and puts non numerics in the year field'
-  scenario 'Citizen is married and puts non numerics in their own day field'
-  scenario 'Citizen is married and puts non numerics in their own month field'
-  scenario 'Citizen is married and puts non numerics in their own year field'
-  scenario 'Citizen is married and puts non numerics in their partners day field'
-  scenario 'Citizen is married and puts non numerics in their partners month field'
-  scenario 'Citizen is married and puts non numerics in their partners year field'
+
+  scenario 'Citizen is married and puts non numerics in their partners month field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.partner_date_of_birth.set('09/July/1970')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.partner_date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+
+  scenario 'Citizen is married and puts non numerics in their partners year field' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.partner_date_of_birth.set('09/08/someyear')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.partner_date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
 end

--- a/spec/features/validate_date_of_birth_spec.rb
+++ b/spec/features/validate_date_of_birth_spec.rb
@@ -181,4 +181,26 @@ RSpec.describe 'Validate date of birth Test', type: :feature, js: true do
     # Assert
     expect(date_of_birth_page.partner_date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.under_age.married'))).to be_present
   end
+
+  # The following scenarios had no acceptance criteria from the business - but are important still
+  scenario 'Citizen is single and puts non numerics in the day field' do
+    # Arrange
+    given_i_am(:veronica)
+    answer_up_to(:date_of_birth)
+
+    # Act
+    date_of_birth_page.date_of_birth.set('01/July/1970')
+    date_of_birth_page.next
+
+    # Assert
+    expect(date_of_birth_page.partner_date_of_birth.error_with_text(messaging.t('hwf_pages.date_of_birth.errors.non_numeric'))).to be_present
+  end
+  scenario 'Citizen is single and puts non numerics in the month field'
+  scenario 'Citizen is single and puts non numerics in the year field'
+  scenario 'Citizen is married and puts non numerics in their own day field'
+  scenario 'Citizen is married and puts non numerics in their own month field'
+  scenario 'Citizen is married and puts non numerics in their own year field'
+  scenario 'Citizen is married and puts non numerics in their partners day field'
+  scenario 'Citizen is married and puts non numerics in their partners month field'
+  scenario 'Citizen is married and puts non numerics in their partners year field'
 end

--- a/spec/features/validate_partner_status_spec.rb
+++ b/spec/features/validate_partner_status_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+# This feature represents the acceptance criteria defined in RST-794
+RSpec.describe 'Validate partner status test', type: :feature, js: true do
+  let(:next_page) { Calculator::Test::En::CourtFeePage.new }
+  # Personas
+  #
+  # JOHN is a single, 56 year old man with 1 child
+  # ALLI is a married, 60 year old man with 1 child
+  # SUE is a married, 75 year old woman with 0 children
+  #
+  #
+  # Scenario: Select Single Marital status option
+  #          Given I am JOHN
+  #          And I am on the Marital status question
+  #          And I select Single option
+  #          When I click on the Next step button
+  #          Then I should see the next question
+  scenario 'Select Single Marital status option' do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to(:marital_status)
+
+    # Act
+    marital_status_page.marital_status.set(messaging.t('hwf_pages.marital_status.labels.marital_status.single'))
+    marital_status_page.next
+
+    # Assert
+    expect(next_page).to be_present
+  end
+
+  #
+  # Scenario: Select Married Marital status option
+  #          Given I am ALLI
+  #          And I am on the Marital status question
+  #          And I select "Married or living with someone" option
+  #          When I click on the Next step button
+  #          Then I should see the next question
+  #
+  scenario 'Select Married Marital status option' do
+    # Arrange
+    given_i_am(:alli)
+    answer_up_to(:marital_status)
+
+    # Act
+    marital_status_page.marital_status.set(messaging.t('hwf_pages.marital_status.labels.marital_status.sharing_income'))
+    marital_status_page.next
+
+    # Assert
+    expect(next_page).to be_present
+  end
+
+  # Scenario: No selection of Marital status option (no entry)
+  #          Given I am JOHN
+  #          And I am on the Marital status question
+  #          And I don't select any option
+  #          When I click on the Next step button
+  #          Then I should see an error message
+  #
+  #      Error Message: "Select whether you're single, married or living with someone and sharing an income"
+  scenario 'No selection of Marital status option (no entry)' do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to(:marital_status)
+
+    # Act
+    marital_status_page.next
+
+    # Assert
+    expect(marital_status_page.error_with_text(messaging.t('hwf_pages.marital_status.errors.blank'))).to be_present
+  end
+
+
+
+
+
+end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -58,6 +58,39 @@ RSpec.describe DateOfBirthForm, type: :model do
         # Assert
         expect(form.errors.details[:date_of_birth]).to be_empty
       end
+
+      it 'disallows a non numeric month field' do
+        # Arrange
+        form = described_class.new('date_of_birth(1i)' => '1970', 'date_of_birth(2i)' => 'July', 'date_of_birth(3i)' => '01')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
+
+      it 'disallows a non numeric day field' do
+        # Arrange
+        form = described_class.new('date_of_birth(1i)' => '1970', 'date_of_birth(2i)' => '07', 'date_of_birth(3i)' => 'First')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
+
+      it 'disallows a non numeric year field' do
+        # Arrange
+        form = described_class.new('date_of_birth(1i)' => 'Millenium', 'date_of_birth(2i)' => 'July', 'date_of_birth(3i)' => '01')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
     end
 
     describe 'partner_date_of_birth' do
@@ -114,6 +147,38 @@ RSpec.describe DateOfBirthForm, type: :model do
 
         # Assert
         expect(form.errors.details[:partner_date_of_birth]).to be_empty
+      end
+      it 'disallows a non numeric month field' do
+        # Arrange
+        form = described_class.new('partner_date_of_birth(1i)' => '1970', 'partner_date_of_birth(2i)' => 'July', 'partner_date_of_birth(3i)' => '01')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:partner_date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
+
+      it 'disallows a non numeric day field' do
+        # Arrange
+        form = described_class.new('partner_date_of_birth(1i)' => '1970', 'partner_date_of_birth(2i)' => '07', 'partner_date_of_birth(3i)' => 'First')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:partner_date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
+
+      it 'disallows a non numeric year field' do
+        # Arrange
+        form = described_class.new('partner_date_of_birth(1i)' => 'Millenium', 'partner_date_of_birth(2i)' => 'July', 'partner_date_of_birth(3i)' => '01')
+
+        # Act
+        form.valid?
+
+        # Assert
+        expect(form.errors.details[:partner_date_of_birth]).to contain_exactly a_hash_including(error: :invalid_date)
       end
     end
   end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows blank' do
         # Arrange
-        form = described_class.new('date_of_birth(1i)' => '', 'date_of_birth(2i)' => '', 'date_of_birth(3i)' => '')
+        form = described_class.new('date_of_birth' => { 'day' => '', 'month' => '', 'year' => '' })
 
         # Act
         form.valid?
@@ -26,7 +26,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'disallows someone who is just under 16' do
         # Arrange
         d = (Time.zone.tomorrow - 16.years)
-        form = described_class.new('date_of_birth(1i)' => d.year.to_s, 'date_of_birth(2i)' => d.month.to_s, 'date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -38,7 +38,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'allows someone who has just turned 16' do
         # Arrange
         d = Time.zone.today - 16.years
-        form = described_class.new('date_of_birth(1i)' => d.year.to_s, 'date_of_birth(2i)' => d.month.to_s, 'date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -50,7 +50,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'allows someone who is 17' do
         # Arrange
         d = Time.zone.today - 17.years
-        form = described_class.new('date_of_birth(1i)' => d.year.to_s, 'date_of_birth(2i)' => d.month.to_s, 'date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -61,7 +61,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric month field' do
         # Arrange
-        form = described_class.new('date_of_birth(1i)' => '1970', 'date_of_birth(2i)' => 'July', 'date_of_birth(3i)' => '01')
+        form = described_class.new('date_of_birth' => { 'year' => '1970', 'month' => 'July', 'day' => '01' })
 
         # Act
         form.valid?
@@ -72,7 +72,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric day field' do
         # Arrange
-        form = described_class.new('date_of_birth(1i)' => '1970', 'date_of_birth(2i)' => '07', 'date_of_birth(3i)' => 'First')
+        form = described_class.new('date_of_birth' => { 'year' => '1970', 'month' => '07', 'day' => 'First' })
 
         # Act
         form.valid?
@@ -83,7 +83,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric year field' do
         # Arrange
-        form = described_class.new('date_of_birth(1i)' => 'Millenium', 'date_of_birth(2i)' => 'July', 'date_of_birth(3i)' => '01')
+        form = described_class.new('date_of_birth' => { 'year' => 'Millenium', 'month' => 'July', 'day' => '01' })
 
         # Act
         form.valid?
@@ -104,7 +104,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows blank' do
         # Arrange
-        form = described_class.new('partner_date_of_birth(1i)' => '', 'partner_date_of_birth(2i)' => '', 'partner_date_of_birth(3i)' => '')
+        form = described_class.new('partner_date_of_birth' => { 'year' => '', 'month' => '', 'day' => '' })
 
         # Act
         form.valid?
@@ -116,7 +116,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'disallows someone who is just under 16' do
         # Arrange
         d = (Time.zone.tomorrow - 16.years)
-        form = described_class.new('partner_date_of_birth(1i)' => d.year.to_s, 'partner_date_of_birth(2i)' => d.month.to_s, 'partner_date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('partner_date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -128,7 +128,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'allows someone who has just turned 16' do
         # Arrange
         d = Time.zone.today - 16.years
-        form = described_class.new('partner_date_of_birth(1i)' => d.year.to_s, 'partner_date_of_birth(2i)' => d.month.to_s, 'partner_date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('partner_date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -140,7 +140,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'allows someone who is 17' do
         # Arrange
         d = Time.zone.today - 17.years
-        form = described_class.new('partner_date_of_birth(1i)' => d.year.to_s, 'partner_date_of_birth(2i)' => d.month.to_s, 'partner_date_of_birth(3i)' => d.day.to_s)
+        form = described_class.new('partner_date_of_birth' => { 'year' => d.year.to_s, 'month' => d.month.to_s, 'day' => d.day.to_s })
 
         # Act
         form.valid?
@@ -151,7 +151,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric month field' do
         # Arrange
-        form = described_class.new('partner_date_of_birth(1i)' => '1970', 'partner_date_of_birth(2i)' => 'July', 'partner_date_of_birth(3i)' => '01')
+        form = described_class.new('partner_date_of_birth' => { 'year' => '1970', 'month' => 'July', 'day' => '01' })
 
         # Act
         form.valid?
@@ -162,7 +162,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric day field' do
         # Arrange
-        form = described_class.new('partner_date_of_birth(1i)' => '1970', 'partner_date_of_birth(2i)' => '07', 'partner_date_of_birth(3i)' => 'First')
+        form = described_class.new('partner_date_of_birth' => { 'year' => '1970', 'month' => '07', 'day' => 'First' })
 
         # Act
         form.valid?
@@ -173,7 +173,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric year field' do
         # Arrange
-        form = described_class.new('partner_date_of_birth(1i)' => 'Millenium', 'partner_date_of_birth(2i)' => '01', 'partner_date_of_birth(3i)' => '01')
+        form = described_class.new('partner_date_of_birth' => { 'year' => 'Millenium', 'month' => '01', 'day' => '01' })
 
         # Act
         form.valid?
@@ -191,8 +191,8 @@ RSpec.describe DateOfBirthForm, type: :model do
   end
 
   describe '#initialize' do
-    it 'converts date of birth from rails 1i, 2i, 3i format from date helpers' do
-      subject = described_class.new('date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => '12', 'date_of_birth(3i)' => '27')
+    it 'converts date of birth from hash format' do
+      subject = described_class.new('date_of_birth' => { 'year' => '2000', 'month' => '12', 'day' => '27' })
       expect(subject.date_of_birth).to eql(Date.new(2000, 12, 27))
     end
 
@@ -201,8 +201,8 @@ RSpec.describe DateOfBirthForm, type: :model do
       expect(subject.date_of_birth).to eql(Date.new(2000, 12, 27))
     end
 
-    it 'converts partner date of birth from rails 1i, 2i, 3i format from date helpers' do
-      subject = described_class.new('partner_date_of_birth(1i)' => '2000', 'partner_date_of_birth(2i)' => '12', 'partner_date_of_birth(3i)' => '28')
+    it 'converts partner date of birth from hash format' do
+      subject = described_class.new('partner_date_of_birth' => { 'year' => '2000', 'month' => '12', 'day' => '28' })
       expect(subject.partner_date_of_birth).to eql(Date.new(2000, 12, 28))
     end
 
@@ -212,19 +212,19 @@ RSpec.describe DateOfBirthForm, type: :model do
     end
 
     it 'allows partner date of birth fields to be nil' do
-      subject = described_class.new 'date_of_birth(1i)' => '2000',
-                                    'date_of_birth(2i)' => '12',
-                                    'date_of_birth(3i)' => '27',
-                                    'partner_date_of_birth(1i)' => nil,
-                                    'partner_date_of_birth(2i)' => nil,
-                                    'partner_date_of_birth(3i)' => nil
+      subject = described_class.new 'date_of_birth' => { 'year' => '2000', 'month' => '12', 'day' => '27'},
+        'partner_date_of_birth' => nil
+      expect(subject.partner_date_of_birth).to be_nil
+    end
+
+    it 'allows partner date of birth field values to be nil' do
+      subject = described_class.new 'date_of_birth' => { 'year' => '2000', 'month' => '12', 'day' => '27'},
+        'partner_date_of_birth' => { 'year' => nil, 'month' => nil, 'day' => nil}
       expect(subject.partner_date_of_birth).to be_nil
     end
 
     it 'allows partner date of birth fields to be undefined' do
-      subject = described_class.new 'date_of_birth(1i)' => '2000',
-                                    'date_of_birth(2i)' => '12',
-                                    'date_of_birth(3i)' => '27'
+      subject = described_class.new 'date_of_birth' => { 'year' => '2000', 'month' => '12', 'day' => '27'}
       expect(subject.partner_date_of_birth).to be_nil
     end
   end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe DateOfBirthForm, type: :model do
         # Assert
         expect(form.errors.details[:partner_date_of_birth]).to be_empty
       end
+
       it 'disallows a non numeric month field' do
         # Arrange
         form = described_class.new('partner_date_of_birth(1i)' => '1970', 'partner_date_of_birth(2i)' => 'July', 'partner_date_of_birth(3i)' => '01')
@@ -172,7 +173,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'disallows a non numeric year field' do
         # Arrange
-        form = described_class.new('partner_date_of_birth(1i)' => 'Millenium', 'partner_date_of_birth(2i)' => 'July', 'partner_date_of_birth(3i)' => '01')
+        form = described_class.new('partner_date_of_birth(1i)' => 'Millenium', 'partner_date_of_birth(2i)' => '01', 'partner_date_of_birth(3i)' => '01')
 
         # Act
         form.valid?

--- a/spec/lib/blank_date_spec.rb
+++ b/spec/lib/blank_date_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'blank_date'
 RSpec.describe BlankDate do
   subject(:blank_date) { described_class.new }
 

--- a/spec/lib/invalid_date_spec.rb
+++ b/spec/lib/invalid_date_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'invalid_date'
+RSpec.describe InvalidDate do
+  subject(:invalid_date) { described_class.new('invalid year', 'invalid month', 'invalid day') }
+
+  describe '#blank?' do
+    it 'returns false' do
+      expect(invalid_date.blank?).to be false
+    end
+  end
+
+  describe '#valid?' do
+    it 'returns false' do
+      expect(invalid_date.valid?).to be false
+    end
+  end
+
+  describe '#day' do
+    it 'returns what was passed in' do
+      expect(invalid_date.day).to eql 'invalid day'
+    end
+  end
+
+  describe '#month' do
+    it 'returns what was passed in' do
+      expect(invalid_date.month).to eql 'invalid month'
+    end
+  end
+
+  describe '#year' do
+    it 'returns what was passed in' do
+      expect(invalid_date.year).to eql 'invalid year'
+    end
+  end
+
+  describe 'is_a?' do
+    it 'must be a date' do
+      expect(invalid_date.is_a?(Date)).to be true
+    end
+  end
+end

--- a/spec/services/benefits_received_calculator_service_spec.rb
+++ b/spec/services/benefits_received_calculator_service_spec.rb
@@ -33,19 +33,24 @@ RSpec.describe BenefitsReceivedCalculatorService do
       result = service.call(benefits_received: [:any_benefit])
       expect(result).to have_attributes available_help: :full
     end
+
+    it 'states that the decision is final if any benefits are provided' do
+      result = service.call(benefits_received: [:any_benefit])
+      expect(result).to have_attributes final_decision?: true
+    end
   end
 
   describe '#fields_required' do
     it 'returns its only field with no inputs provided' do
       # Act
-      result = described_class.fields_required({}, previous_calculations: {})
+      result = described_class.fields_required({})
 
       # Assert
       expect(result).to eql [:benefits_received]
     end
     it 'returns no fields if all inputs have been provided' do
       # Act
-      result = described_class.fields_required({ benefits_received: ['benefit 1'] }, previous_calculations: {})
+      result = described_class.fields_required({ benefits_received: ['benefit 1'] })
 
       # Assert
       expect(result).to eql []

--- a/spec/services/calculation_service_spec.rb
+++ b/spec/services/calculation_service_spec.rb
@@ -253,21 +253,14 @@ RSpec.describe CalculationService do
         disposable_capital: 1000
       }
     end
-    let(:expected_previous_calculations) do
-      {
-        calculator1: { available_help: :undecided },
-        calculator2: { available_help: :undecided },
-        calculator3: { available_help: :undecided }
-      }
-    end
 
     include_context 'with fake calculators'
     before do
-      # Arrange - Each calculator class can tell us which fields are required based on inputs and previous calculations
+      # Arrange - Each calculator class can tell us which fields are required based on inputs
       # Here we just give some dummy data - it is not relevant as long as they all get added together in the correct order
-      allow(calculator_1_class).to receive(:fields_required).with(inputs, previous_calculations: an_instance_of(Hash)).and_return([:fee])
-      allow(calculator_2_class).to receive(:fields_required).with(inputs, previous_calculations: an_instance_of(Hash)).and_return([:date_of_birth, :benefits_received])
-      allow(calculator_3_class).to receive(:fields_required).with(inputs, previous_calculations: an_instance_of(Hash)).and_return([:number_of_children, :total_income])
+      allow(calculator_1_class).to receive(:fields_required).with(inputs).and_return([:fee])
+      allow(calculator_2_class).to receive(:fields_required).with(inputs).and_return([:date_of_birth, :benefits_received])
+      allow(calculator_3_class).to receive(:fields_required).with(inputs).and_return([:number_of_children, :total_income])
     end
 
     it 'returns any fields not provided in the input in the correct order prefixed with marital_status' do
@@ -276,22 +269,22 @@ RSpec.describe CalculationService do
       expect(service.call(inputs, calculators: calculators)).to have_attributes fields_required: [:marital_status, :fee, :date_of_birth, :benefits_received, :number_of_children, :total_income]
     end
 
-    it 'calls fields_required on calculator 1 class with previous calculations' do
+    it 'calls fields_required on calculator 1 class' do
       # Act and Assert
       service.call(inputs, calculators: calculators).fields_required
-      expect(calculator_1_class).to have_received(:fields_required).with(inputs, previous_calculations: expected_previous_calculations)
+      expect(calculator_1_class).to have_received(:fields_required).with(inputs)
     end
 
-    it 'calls fields_required on calculator 2 class with previous calculations' do
+    it 'calls fields_required on calculator 2 class' do
       # Act and Assert
       service.call(inputs, calculators: calculators).fields_required
-      expect(calculator_2_class).to have_received(:fields_required).with(inputs, previous_calculations: expected_previous_calculations)
+      expect(calculator_2_class).to have_received(:fields_required).with(inputs)
     end
 
-    it 'calls fields_required on calculator 3 class with previous calculations' do
+    it 'calls fields_required on calculator 3 class' do
       # Act and Assert
       service.call(inputs, calculators: calculators).fields_required
-      expect(calculator_3_class).to have_received(:fields_required).with(inputs, previous_calculations: expected_previous_calculations)
+      expect(calculator_3_class).to have_received(:fields_required).with(inputs)
     end
 
   end

--- a/spec/services/disposable_capital_calculator_service_spec.rb
+++ b/spec/services/disposable_capital_calculator_service_spec.rb
@@ -118,21 +118,21 @@ RSpec.describe DisposableCapitalCalculatorService do
   describe '#fields_required' do
     it 'returns all 4 fields with no inputs provided' do
       # Act
-      result = described_class.fields_required({}, previous_calculations: {})
+      result = described_class.fields_required({})
 
       # Assert
       expect(result).to eql [:fee, :date_of_birth, :partner_date_of_birth, :disposable_capital]
     end
     it 'returns 3 fields with 1 input provided' do
       # Act
-      result = described_class.fields_required({ fee: 10.0 }, previous_calculations: {})
+      result = described_class.fields_required({ fee: 10.0 })
 
       # Assert
       expect(result).to eql [:date_of_birth, :partner_date_of_birth, :disposable_capital]
     end
     it 'returns no fields if all inputs have been provided' do
       # Act
-      result = described_class.fields_required({ fee: 10.0, date_of_birth: 20.years.ago, partner_date_of_birth: nil, disposable_capital: 10000.0 }, previous_calculations: {})
+      result = described_class.fields_required({ fee: 10.0, date_of_birth: 20.years.ago, partner_date_of_birth: nil, disposable_capital: 10000.0 })
 
       # Assert
       expect(result).to eql []

--- a/spec/types/strict_date_type_spec.rb
+++ b/spec/types/strict_date_type_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+RSpec.describe StrictDateType do
+  class TestInvalidDate < Date
+    def self.new(*)
+      super()
+    end
+  end
+
+  class TestBlankDate < Date
+    def blank?
+      true
+    end
+  end
+
+  describe '#cast' do
+    subject(:type) { described_class.new(invalid_date_class: TestInvalidDate, blank_date_class: TestBlankDate) }
+
+    it 'casts a valid date hash to a date' do
+      expect(type.cast(year: '2010', month: '11', day: '13')).to eql(Date.new(2010, 11, 13))
+    end
+
+    it 'casts a valid date hash with zero prefixed months and days to a date' do
+      expect(type.cast(year: '2010', month: '09', day: '08')).to eql(Date.new(2010, 9, 8))
+    end
+
+    it 'casts a date hash with invalid year to an InvalidDate' do
+      expect(type.cast(year: 'invalid', month: '11', day: '13')).to be_a(TestInvalidDate)
+    end
+
+    it 'casts a date hash with invalid month to an InvalidDate' do
+      expect(type.cast(year: '2010', month: 'july', day: '13')).to be_a(TestInvalidDate)
+    end
+
+    it 'casts a date hash with invalid day to an InvalidDate' do
+      expect(type.cast(year: '2010', month: '11', day: 'someday')).to be_a(TestInvalidDate)
+    end
+
+    it 'casts a blank hash to nil' do
+      expect(type.cast({})).to be_nil
+    end
+
+    it 'casts a hash with all blank values to a BlankDate' do
+      expect(type.cast(year: '', month: '', day: '')).to be_a(TestBlankDate)
+    end
+
+    it 'casts a date if a date is given' do
+      expect(type.cast(Date.new(1980,1,1))).to eql Date.new(1980,1,1)
+    end
+  end
+end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+RSpec.describe DateValidator do
+  context 'when age greater than or equal to 16' do
+    # The validator uses the special 'InvalidDate' which we will mock our own and inject it into the validator
+    class MyInvalidDate < Date
+
+    end
+
+    # As the validator interface is not ours, it belongs to active model,
+    # then use the validator as it is supposed to be used in a test class
+    # and test the functionality from there.
+    let(:model_class) do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :date
+
+        def self.name
+          'MyModel'
+        end
+
+        validates :date, date: { invalid_date_class: MyInvalidDate }
+      end
+    end
+
+    context 'with an invalid date' do
+      it 'disallows the invalid date' do
+        # Arrange
+        date = MyInvalidDate.new(1970,1,1)
+        model = model_class.new(date: date)
+
+        # Act
+        model.valid?
+
+        # Assert
+        expect(model.errors.details[:date]).to contain_exactly a_hash_including(error: :invalid_date)
+      end
+    end
+
+    context 'with a valid date' do
+      it 'allows the valid date' do
+        # Arrange
+        model = model_class.new(date: Time.zone.today)
+
+        # Act
+        model.valid?
+
+        # Assert
+        expect(model.errors.details[:date]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/validators/strict_date_validator_spec.rb
+++ b/spec/validators/strict_date_validator_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.describe DateValidator do
+RSpec.describe StrictDateValidator do
   context 'when age greater than or equal to 16' do
     # The validator uses the special 'InvalidDate' which we will mock our own and inject it into the validator
     class MyInvalidDate < Date
@@ -18,7 +18,7 @@ RSpec.describe DateValidator do
           'MyModel'
         end
 
-        validates :date, date: { invalid_date_class: MyInvalidDate }
+        validates :date, strict_date: { invalid_date_class: MyInvalidDate }
       end
     end
 

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -80,6 +80,8 @@ en:
             student maintenance loans, grants or bursaries (except for tuition fee loans)
             If you or your partner's income varies from month to month, work out an average monthly income based on the last 3 months. See the guide for further details of what to include and exclude.
     marital_status:
+      errors:
+        blank: "Select whether you're single, married or living with someone and sharing an income"
       labels:
         marital_status:
           single: Single

--- a/test_common/page_objects/en/calculator/date_of_birth_page.rb
+++ b/test_common/page_objects/en/calculator/date_of_birth_page.rb
@@ -5,7 +5,7 @@ module Calculator
         set_url '/calculation/date_of_birth'
         element :heading, :exact_heading_text, 'Find out if you could get help with fees'
         section :date_of_birth, ::Calculator::Test::DateOfBirthQuestionSection, :calculator_question, 'What is your date of birth?'
-        section :partner_date_of_birth, ::Calculator::Test::QuestionDateSection, :calculator_question, 'What is your partners date of birth?'
+        section :partner_date_of_birth, ::Calculator::Test::DateOfBirthQuestionSection, :calculator_question, 'What is your partners date of birth?'
         element :next_button, :button, 'Next step'
 
         def next

--- a/test_common/page_objects/en/calculator/marital_status_page.rb
+++ b/test_common/page_objects/en/calculator/marital_status_page.rb
@@ -33,6 +33,16 @@ module Calculator
         def wait_for_guidance
           marital_status.wait_for_help_text
         end
+
+        # Find an error matching the given text in the marital_status field
+        #
+        # @param [String] text The error message to match
+        #
+        # @return [Capybara::Node::Element] The node found
+        # @raise [Capybara::ElementNotFound] If an error message could not be found
+        def error_with_text(text)
+          marital_status.error_with_text(text)
+        end
       end
     end
   end

--- a/test_common/sections/feedback.rb
+++ b/test_common/sections/feedback.rb
@@ -2,19 +2,27 @@ module Calculator
   module Test
     class FeedbackSection < BaseSection
       def message_with_detail(msg)
-        find '[data-behavior=calculator_feedback_message]', text: msg
+        within @root_element do
+          find '[data-behavior=calculator_feedback_message]', text: msg
+        end
       end
 
       def message_with_header(header)
-        find '[data-behavior=calculator_feedback_header]', text: header
+        within @root_element do
+          find '[data-behavior=calculator_feedback_header]', text: header
+        end
       end
 
       def positive_message
-        find '.positive'
+        within @root_element do
+          find '.positive'
+        end
       end
 
       def negative_message
-        find '.negative'
+        within @root_element do
+          find '.negative'
+        end
       end
     end
   end

--- a/test_common/sections/question_checkbox_list.rb
+++ b/test_common/sections/question_checkbox_list.rb
@@ -7,14 +7,18 @@ module Calculator
       sections :options, GdsMultipleChoiceOptionSection, :gds_multiple_choice_option
       # @param [Array<String>] values An array of checkboxes to select by value
       def set(values)
-        values.each do |value|
-          check value
+        within @root_element do
+          values.each do |value|
+            check value
+          end
         end
       end
 
       def option_labelled(text)
-        node = find :gds_multiple_choice_option, text: text
-        GdsMultipleChoiceOptionSection.new self, node
+        within @root_element do
+          node = find :gds_multiple_choice_option, text: text
+          GdsMultipleChoiceOptionSection.new self, node
+        end
       end
     end
   end

--- a/test_common/sections/question_radio_list.rb
+++ b/test_common/sections/question_radio_list.rb
@@ -3,7 +3,9 @@ module Calculator
   module Test
     class QuestionRadioListSection < QuestionSection
       def set(value)
-        choose(value)
+        within @root_element do
+          choose(value)
+        end
       end
     end
   end

--- a/test_common/sections/question_section.rb
+++ b/test_common/sections/question_section.rb
@@ -10,7 +10,9 @@ module Calculator
         # Important, do not be tempted to change this to a css selector with text: text - as it matches
         # partial text, not exact
         xpath = XPath.generate { |x| x.descendant(:span)[x.string.n.is(text)] }
-        find(:xpath, xpath, class: 'error-message', exact: true)
+        within @root_element do
+          find(:xpath, xpath, class: 'error-message', exact: true)
+        end
       end
 
       def hint_with_text(text)


### PR DESCRIPTION
This PR is for an umbrella ticket covering the following tickets

RST-794 RST-781 RST-778 RST-787 and RST-733

These are primarily validation tickets, hence they have been grouped together.

Here is what has changed :-

The date fields are now using a 'hash' format {year: '2010', month: '6', day: '20'} instead of the silly (1i), (2i), (3i) format that rails uses.  As it turns out this silly format is actually active record's thing - and we are not using active record so we are not following this silly thing.
The hash format is the same as that used in ET - so we have more consistency now with other projects.

The conversion from this hash format to a date is now done in an active model serializer rather than in the form object itself.  So, the date_of_birth_form has become a lot simpler.

2 special 'dates' - 'InvalidDate' and 'BlankDate' allow the form objects to always return a date irrespective of what junk the user put in.  The validators will then check for these special classes.  Instances of these quack like a date, so the view layer can call 'day', 'month', 'year' on them.

As the calculator's are now capable of saying that their results are final and no more questions should be asked, there is no longer a need to track the results of previous calculations.  This has simplified the calculation_service.

The benefits received calculator now sets its 'final_decision' to true - rather than relying on previous calculations like before.

The household income calculator is no longer dependent on the previous calculations, tidying up the interface.

A 'strict_date validator' has been added which validates the strict_date's to make sure they are valid.  Allows custom messages to the user when they have put some rubbish in.

All pages now share a common 'feedback' partial to DRY up the code

Resolved layout inconsistencies with positioning of help text, error text and input fields - it is now as per the prototype.

