### PR TITLE
RST-833 - Dynamic label for number of children

### DIFF
--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -4,7 +4,7 @@
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset
         legend
-          h2.heading-medium = 'How many children live with you or are you responsible for supporting financially?'
+          h2.heading-medium = t("calculation.field_labels.number_of_children.#{current_calculation.inputs['marital_status']}")
         - if form.errors.include?(:number_of_children)
           span.error-message = form.errors[:number_of_children].join(', ')
         label.block-label

--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -4,7 +4,7 @@
     .form-group class=('form-group-error' if form.errors.any?)
       fieldset
         legend
-          h2.heading-medium = t("calculation.field_labels.number_of_children.#{current_calculation.inputs['marital_status']}")
+          h2.heading-medium = t("calculation.field_labels.number_of_children.#{current_calculation.inputs[:marital_status]}")
         - if form.errors.include?(:number_of_children)
           span.error-message = form.errors[:number_of_children].join(', ')
         label.block-label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,9 @@ en:
       benefits_received: "Select all income benefits you are currently receiving"
       total_income: "How much total income do you receive each month?"
       partner_date_of_birth: "What is your partners date of birth?"
+      number_of_children:
+        single: "How many children live with you or are you responsible for supporting financially?"
+        sharing_income: "How many children live with you and your partner or are you and your partner responsible for supporting financially?"
     previous_questions:
       disposable_capital:
         label: "Combined savings and investment"

--- a/spec/features/income_related_benefits_spec.rb
+++ b/spec/features/income_related_benefits_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe 'Income Benefit Page Content', type: :feature, js: true do
     # Arrange - Take alli to the benefits page
     given_i_am(:alli)
     answer_up_to(:benefits)
-    marital_status = user.marital_status
 
     # Act
     income_benefits_page.choose(:none)
@@ -163,7 +162,6 @@ RSpec.describe 'Income Benefit Page Content', type: :feature, js: true do
     # Arrange - Take alli to the benefits page
     given_i_am(:alli)
     answer_up_to(:benefits)
-    marital_status = user.marital_status
 
     # Act
     income_benefits_page.choose(:dont_know)

--- a/spec/features/view_number_of_children_spec.rb
+++ b/spec/features/view_number_of_children_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
   #
   #
   #
-  # Scenario: View Number of Children Heading and Question
+  # Scenario: View Number of Children Heading and Question (single)
   #               Given I am on the Number of Children page
   #               When I view the Heading and Number of Children question
   #               Then Heading reads "Find out if you can get help with fees"
@@ -20,7 +20,26 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
     # Assert
     aggregate_failures 'validating content of header and question' do
       expect(number_of_children_page.heading).to be_present
-      expect(number_of_children_page.number_of_children).to be_present
+      expect(number_of_children_page.number_of_children_single).to be_present
+    end
+  end
+
+  # Scenario: View Number of Children Heading and Question (married)
+  #               Given I am on the Number of Children page
+  #               When I view the Heading and Number of Children question
+  #               Then Heading reads "Find out if you can get help with fees"
+  #               And question reads "How many children live with you and your partner or are you and your partner responsible for supporting financially? "
+  scenario 'View Number of Children Heading and Question' do
+    # Arrange
+    given_i_am(:alli)
+
+    # Act
+    answer_up_to(:number_of_children)
+
+    # Assert
+    aggregate_failures 'validating content of header and question' do
+      expect(number_of_children_page.heading).to be_present
+      expect(number_of_children_page.number_of_children_married).to be_present
     end
   end
   #

--- a/spec/features/view_number_of_children_spec.rb
+++ b/spec/features/view_number_of_children_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
   #               When I view the Heading and Number of Children question
   #               Then Heading reads "Find out if you can get help with fees"
   #               And question reads "How many children live with you or are you responsible for supporting financially?"
-  scenario 'View Number of Children Heading and Question' do
+  scenario 'View Number of Children Heading and Question (single)' do
     # Arrange
     given_i_am(:john)
 
@@ -20,7 +20,7 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
     # Assert
     aggregate_failures 'validating content of header and question' do
       expect(number_of_children_page.heading).to be_present
-      expect(number_of_children_page.number_of_children_single).to be_present
+      expect(number_of_children_page).to have_number_of_children_single
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
   #               When I view the Heading and Number of Children question
   #               Then Heading reads "Find out if you can get help with fees"
   #               And question reads "How many children live with you and your partner or are you and your partner responsible for supporting financially? "
-  scenario 'View Number of Children Heading and Question' do
+  scenario 'View Number of Children Heading and Question (married)' do
     # Arrange
     given_i_am(:alli)
 
@@ -39,7 +39,7 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
     # Assert
     aggregate_failures 'validating content of header and question' do
       expect(number_of_children_page.heading).to be_present
-      expect(number_of_children_page.number_of_children_married).to be_present
+      expect(number_of_children_page).to have_number_of_children_married
     end
   end
   #

--- a/test_common/capybara_selectors/question.rb
+++ b/test_common/capybara_selectors/question.rb
@@ -1,8 +1,15 @@
+# This selector matches a calculator question which is labelled by one or more
+# of the provided locators (can be single string or an array of strings)
 Capybara.add_selector(:calculator_question) do
   xpath do |locator, _options|
     XPath.generate do |x|
+      locators = Array(locator).dup
+      legends = x.string.n.is(locators.shift)
+      until locators.empty? do
+        legends = legends.or x.string.n.is(locators.shift)
+      end
       x.descendant(:div)[x.attr(:class).contains('form-group') &
-                         x.child(:fieldset)[x.descendant(:legend)[x.string.n.is(locator)]]]
+        x.child(:fieldset)[x.descendant(:legend)[legends]]]
     end
   end
 end

--- a/test_common/capybara_selectors/question.rb
+++ b/test_common/capybara_selectors/question.rb
@@ -5,11 +5,9 @@ Capybara.add_selector(:calculator_question) do
     XPath.generate do |x|
       locators = Array(locator).dup
       legends = x.string.n.is(locators.shift)
-      until locators.empty? do
-        legends = legends.or x.string.n.is(locators.shift)
-      end
+      legends = legends.or x.string.n.is(locators.shift) until locators.empty?
       x.descendant(:div)[x.attr(:class).contains('form-group') &
-        x.child(:fieldset)[x.descendant(:legend)[legends]]]
+                         x.child(:fieldset)[x.descendant(:legend)[legends]]]
     end
   end
 end

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -65,7 +65,9 @@ en:
       heading: 'Find out if you could get help with fees'
       questions:
         number_of_children:
-          label: 'How many children live with you or are you responsible for supporting financially?'
+          label:
+            single: 'How many children live with you or are you responsible for supporting financially?'
+            sharing_income: 'How many children live with you and your partner or are you and your partner responsible for supporting financially?'
           errors:
             non_numeric: You must enter the number of financially dependent children
             blank: You must enter the number of financially dependent children

--- a/test_common/page_objects/calculator/number_of_children_page.rb
+++ b/test_common/page_objects/calculator/number_of_children_page.rb
@@ -8,17 +8,17 @@ module Calculator
       element :heading, :exact_heading_text, t('hwf_pages.number_of_children.heading')
       element :next_button, :button, t('hwf_pages.number_of_children.buttons.next')
 
-      section :number_of_children, :calculator_question, [CHILDREN_SINGLE_LABEL, CHILDREN_MARRIED_LABEL] do
+      section :number_of_children, :calculator_question, [CHILDREN_SINGLE_LABEL, CHILDREN_MARRIED_LABEL], exact: true do
         @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
         include ::Calculator::Test::NumberOfChildrenQuestionSection
       end
 
-      section :number_of_children_single, :calculator_question, CHILDREN_SINGLE_LABEL do
+      section :number_of_children_single, :calculator_question, CHILDREN_SINGLE_LABEL, exact: true do
         @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
         include ::Calculator::Test::NumberOfChildrenQuestionSection
       end
 
-      section :number_of_children_married, :calculator_question, CHILDREN_MARRIED_LABEL do
+      section :number_of_children_married, :calculator_question, CHILDREN_MARRIED_LABEL, exact: true do
         @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
         include ::Calculator::Test::NumberOfChildrenQuestionSection
       end

--- a/test_common/page_objects/calculator/number_of_children_page.rb
+++ b/test_common/page_objects/calculator/number_of_children_page.rb
@@ -1,11 +1,24 @@
 module Calculator
   module Test
     class NumberOfChildrenPage < BasePage
+      CHILDREN_SINGLE_LABEL = t('hwf_pages.number_of_children.questions.number_of_children.label.single')
+      CHILDREN_MARRIED_LABEL = t('hwf_pages.number_of_children.questions.number_of_children.label.sharing_income')
+
       set_url '/calculation/number_of_children'
       element :heading, :exact_heading_text, t('hwf_pages.number_of_children.heading')
       element :next_button, :button, t('hwf_pages.number_of_children.buttons.next')
 
-      section :number_of_children, :calculator_question, t('hwf_pages.number_of_children.questions.number_of_children.label') do
+      section :number_of_children, :calculator_question, [CHILDREN_SINGLE_LABEL, CHILDREN_MARRIED_LABEL] do
+        @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
+        include ::Calculator::Test::NumberOfChildrenQuestionSection
+      end
+
+      section :number_of_children_single, :calculator_question, CHILDREN_SINGLE_LABEL do
+        @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
+        include ::Calculator::Test::NumberOfChildrenQuestionSection
+      end
+
+      section :number_of_children_married, :calculator_question, CHILDREN_MARRIED_LABEL do
         @i18n_scope = 'hwf_pages.number_of_children.questions.number_of_children'
         include ::Calculator::Test::NumberOfChildrenQuestionSection
       end


### PR DESCRIPTION
This PR implements RST-833 allowing the label for the number of children to be dynamic so the question wording can change depending on if married or not