### PR TITLE
Tidied up the way error messages are shown to the user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-- bundle exec parallel_rspec -n 4 --runtime-log tmp/parallel_runtime_log/rspec.log spec
-- export TEST_LOCALE=cy; bundle exec parallel_rspec -n 4 --runtime-log tmp/parallel_runtime_log/rspec.log spec
-- bundle exec parallel_cucumber -n 4 features/*.feature
-- export TEST_LOCALE=cy; bundle exec parallel_cucumber -n 4 features/*.feature
+- bundle exec parallel_rspec -n 3 --runtime-log tmp/parallel_runtime_log/rspec.log spec
+- export TEST_LOCALE=cy; bundle exec parallel_rspec -n 3 --runtime-log tmp/parallel_runtime_log/rspec.log spec
+- bundle exec parallel_cucumber -n 3 features/*.feature
+- export TEST_LOCALE=cy; bundle exec parallel_cucumber -n 3 features/*.feature
 after_success:
 - bundle exec codeclimate-test-reporter
 after_script:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,9 +22,10 @@ module ApplicationHelper
   def gds_error_messages(model:, method:)
     errors = model.errors
     return '' unless errors.include?(method)
-    errors.full_messages_for(method).each do |error|
+    errors[method].each do |error|
       concat content_tag('span', error, class: 'error-message')
     end
+    nil
   end
 
   def calculation_inputs_by_form(calculation)

--- a/app/views/calculation/_benefits_received.html.slim
+++ b/app/views/calculation/_benefits_received.html.slim
@@ -5,10 +5,8 @@
       fieldset
         legend
           h2.heading-medium = I18n.t('calculation.field_labels.benefits_received')
-        - if form.errors.include?(:benefits_received)
-          span.error-message = form.errors[:benefits_received].join(', ')
+        = gds_error_messages(model: f.object, method: :benefits_received)
         label
-          = gds_error_messages(model: f.object, method: :benefits_received)
           = gds_multiple_choices_with_guidance(form: f, method: :benefits_received, choices: form.benefits.map {|benefit| [benefit, t("calculation.benefits.#{benefit}.label"), t("calculation.benefits.#{benefit}.guidance", raise: false)]})
         details data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.income_benefits.summary')

--- a/app/views/calculation/_date_of_birth.html.slim
+++ b/app/views/calculation/_date_of_birth.html.slim
@@ -7,8 +7,7 @@
           h2.heading-medium = t('calculation.field_labels.date_of_birth')
 
         span.form-hint = t("calculation.hints.date_of_birth.#{current_calculation.inputs[:marital_status]}")
-        - if form.errors.include?(:date_of_birth)
-          span.error-message = form.errors[:date_of_birth].join(', ')
+        = gds_error_messages(model: f.object, method: :date_of_birth)
         .form-date
           .form-group
             label.block-label

--- a/app/views/calculation/_disposable_capital.html.slim
+++ b/app/views/calculation/_disposable_capital.html.slim
@@ -6,8 +6,7 @@
         legend
           h2.heading-medium = t('calculation.field_labels.disposable_capital')
         span.form-hint = t('calculation.hints.disposable_capital')
-        - if form.errors.include?(:disposable_capital)
-          span.error-message = form.errors[:disposable_capital].join(', ')
+        = gds_error_messages(model: f.object, method: :disposable_capital)
         label.block-label
           .form-control-money.gbp
             = f.text_field :disposable_capital, class: 'form-control'

--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -6,8 +6,7 @@
         legend
           h2.heading-medium = t('calculation.field_labels.fee')
         span.form-hint = t('calculation.hints.fee')
-        - if form.errors.include?(:fee)
-          span.error-message = form.errors[:fee].join(', ')
+        = gds_error_messages(model: f.object, method: :fee)
         label.block-label
           .form-control-money.gbp
             = f.text_field :fee, class: 'form-control money gbp'

--- a/app/views/calculation/_marital_status.html.slim
+++ b/app/views/calculation/_marital_status.html.slim
@@ -6,8 +6,7 @@
       fieldset
         legend
           h2.heading-medium = t('calculation.field_labels.marital_status')
-        - if form.errors.include?(:marital_status)
-          span.error-message = form.errors[:marital_status].join(', ')
+        = gds_error_messages(model: f.object, method: :marital_status)
         .multiple-choice
           = f.radio_button :marital_status, 'single'
           = f.label :marital_status_single, t('calculation.marital_status.options.single'), allow_method_names_outside_object: true

--- a/app/views/calculation/_number_of_children.html.slim
+++ b/app/views/calculation/_number_of_children.html.slim
@@ -5,8 +5,7 @@
       fieldset
         legend
           h2.heading-medium = t("calculation.field_labels.number_of_children.#{current_calculation.inputs[:marital_status]}")
-        - if form.errors.include?(:number_of_children)
-          span.error-message = form.errors[:number_of_children].join(', ')
+        = gds_error_messages(model: f.object, method: :number_of_children)
         label.block-label
           = f.text_field :number_of_children, class: 'form-control'
         details data-behavior="question_help"

--- a/app/views/calculation/_total_income.html.slim
+++ b/app/views/calculation/_total_income.html.slim
@@ -6,8 +6,7 @@
         legend
           h2.heading-medium = t('calculation.field_labels.total_income')
         span.form-hint = t('calculation.hints.total_income')
-        - if form.errors.include?(:total_income)
-          span.error-message = form.errors[:total_income].join(', ')
+        = gds_error_messages(model: f.object, method: :total_income)
         label.block-label
           .form-control-money.gbp
             = f.text_field :total_income, class: 'form-control'

--- a/spec/features/change_previous_answers_spec.rb
+++ b/spec/features/change_previous_answers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Change previous answers test', type: :feature, js: true do
     # Assert
     aggregate_failures 'Verify all' do
       expect(marital_status_page).to be_displayed
-      expect(marital_status_page).to have_no_previous_answers
+      expect(marital_status_page).to have_no_previous_answers(wait: 10)
       expect(marital_status_page.marital_status).to have_value(user.marital_status)
     end
   end

--- a/spec/features/change_previous_answers_spec.rb
+++ b/spec/features/change_previous_answers_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'Change previous answers test', type: :feature, js: true do
     # Assert
     aggregate_failures 'Verify all' do
       expect(marital_status_page).to be_displayed
-      marital_status_page.wait_until_previous_answers_invisible
       expect(marital_status_page).to have_no_previous_answers
       expect(marital_status_page.marital_status).to have_value(user.marital_status)
     end


### PR DESCRIPTION
RST-852 - Originally created because I could not find a spec to prove the validation for the income benefits.  But, I found it eventually.  

But, there was extra content on the page that should not have been there and of course the tests did not spot that.  This was to do with the way error messages were presented to the user and is now fixed