### PR TITLE
RST-908 - The previous answers for benefits are no longer abbreviated

### DIFF
--- a/app/views/calculation/forms/_benefits_received.html.slim
+++ b/app/views/calculation/forms/_benefits_received.html.slim
@@ -2,7 +2,8 @@ tr data-behavior="calculator_previous_question"
   th scope='row' data-behavior="question"
     = t("calculation.previous_questions.benefits_received.label")
   td data-behavior="answer"
-    = inputs[:benefits_received].map { |v| t("calculation.previous_questions.benefits_received.#{v}") }.join(',')
+    - inputs[:benefits_received].map do |v|
+      .answer-row = t("calculation.previous_questions.benefits_received.#{v}")
   td data-behavior="action"
     - unless disabled
       a href=edit_calculation_url(form: form_type)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -127,7 +127,7 @@ cy:
         label: "Cyfanswm eich cynilion a’ch buddsoddiadau ar y cyd"
       marital_status:
         label: "Beth yw eich statws"
-        single: "*Welsh Single"
+        single: "Sengl"
         sharing_income: "*Welsh Married or living with someone"
       date_of_birth:
         label: "Dyddiad geni"
@@ -139,12 +139,12 @@ cy:
         label: "Budd-daliadau incwm yr ydych chi’n eu cael ar hyn o bryd"
         dont_know: "Ddim yn gwybod"
         none: 'Dim'
-        jobseekers_allowance: '*Welsh JSA'
-        employment_support_allowance: '*Welsh ESA'
-        income_support: '*Welsh IS'
-        universal_credit: '*Welsh UC'
-        pension_credit: '*Welsh PC'
-        scottish_legal_aid: '*Welsh SLA'
+        jobseekers_allowance: 'Lwfans Ceisio Gwaith yn seiliedig ar incwm (JSA)'
+        employment_support_allowance: 'Lwfans Cyflogaeth a Chymorth yn seiliedig ar incwm (ESA)'
+        income_support: 'Cymhorthdal Incwm'
+        universal_credit: 'Credyd Cynhwysol'
+        pension_credit: 'Credyd Pensiwn'
+        scottish_legal_aid: 'Cymorth Cyfreithiol Sifil Yr Alban'
       number_of_children:
         label: "Plant yr ydych chi’n eu cefnogi"
       total_income:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,12 +140,12 @@ en:
         label: "Income benefits you are currently receiving"
         dont_know: "Don't know"
         none: 'none'
-        jobseekers_allowance: 'JSA'
-        employment_support_allowance: 'ESA'
-        income_support: 'IS'
-        universal_credit: 'UC'
-        pension_credit: 'PC'
-        scottish_legal_aid: 'SLA'
+        jobseekers_allowance: 'Income-based Jobseeker’s Allowance (JSA)'
+        employment_support_allowance: 'Income-related Employment and Support Allowance (ESA)'
+        income_support: 'Income Support'
+        universal_credit: 'Universal Credit'
+        pension_credit: 'Pension Credit'
+        scottish_legal_aid: 'Scottish Civil Legal Aid'
       number_of_children:
         label: "Supported children"
       total_income:

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -291,7 +291,7 @@ cy:
         change: 'Newid'
         options:
           sharing_income: '*Welsh Married or living with someone'
-          single: '*Welsh Single'
+          single: 'Sengl'
       court_fee:
         label: "Ffi’r llys neu’r tribiwnlys i’w thalu"
         change: 'Newid'
@@ -310,12 +310,12 @@ cy:
         options:
           dont_know: "Ddim yn gwybod"
           none: 'Dim'
-          jobseekers_allowance: '*Welsh JSA'
-          employment_support_allowance: '*Welsh ESA'
-          income_support: '*Welsh IS'
-          universal_credit: '*Welsh UC'
-          pension_credit: '*Welsh PC'
-          scottish_legal_aid: '*Welsh SLA'
+          jobseekers_allowance: 'Lwfans Ceisio Gwaith yn seiliedig ar incwm (JSA)'
+          employment_support_allowance: 'Lwfans Cyflogaeth a Chymorth yn seiliedig ar incwm (ESA)'
+          income_support: 'Cymhorthdal Incwm'
+          universal_credit: 'Credyd Cynhwysol'
+          pension_credit: 'Credyd Pensiwn'
+          scottish_legal_aid: 'Cymorth Cyfreithiol Sifil Yr Alban'
       number_of_children:
         label: "Plant yr ydych chi’n eu cefnogi"
         change: 'Newid'

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -311,12 +311,12 @@ en:
         options:
           dont_know: "Don't know"
           none: 'none'
-          jobseekers_allowance: 'JSA'
-          employment_support_allowance: 'ESA'
-          income_support: 'IS'
-          universal_credit: 'UC'
-          pension_credit: 'PC'
-          scottish_legal_aid: 'SLA'
+          jobseekers_allowance: 'Income-based Jobseeker’s Allowance (JSA)'
+          employment_support_allowance: 'Income-related Employment and Support Allowance (ESA)'
+          income_support: 'Income Support'
+          universal_credit: 'Universal Credit'
+          pension_credit: 'Pension Credit'
+          scottish_legal_aid: 'Scottish Civil Legal Aid'
       number_of_children:
         label: "Supported children"
         change: 'Change'

--- a/test_common/sections/previous_questions.rb
+++ b/test_common/sections/previous_questions.rb
@@ -64,8 +64,8 @@ module Calculator
           include ::Calculator::Test::PreviousQuestionSection
 
           def has_answered?(benefits)
-            expected_str = benefits.map { |benefit| t("hwf_components.previous_questions.income_benefits.options.#{benefit}") }.join(',')
-            has_answer?(text: expected_str)
+            expected_str = benefits.map { |benefit| t("hwf_components.previous_questions.income_benefits.options.#{benefit}") }.join("\n")
+            answer.has_text?(expected_str, exact: false)
           end
         end
 


### PR DESCRIPTION
RST-908 - The previous answers for benefits are no longer abbreviated

This PR is purely presentational - previously the 'Previous Answers' section used to show a comma separated list of abbreviated benefits - now it produces a new row per benefit