### PR TITLE
Fixed issue where previous messages from the calculation were not bei…

### DIFF
--- a/app/controllers/calculation_controller.rb
+++ b/app/controllers/calculation_controller.rb
@@ -3,6 +3,7 @@
 class CalculationController < ApplicationController
   include CalculationStore
   helper_method :form
+  before_action :start_again, if: :calculation_frozen?, except: :home
 
   def home
     repo.delete_all
@@ -62,5 +63,13 @@ class CalculationController < ApplicationController
       date_of_birth: [:day, :month, :year],
       partner_date_of_birth: [:day, :month, :year],
       benefits_received: []
+  end
+
+  def calculation_frozen?
+    current_calculation.frozen?
+  end
+
+  def start_again
+    redirect_to root_path
   end
 end

--- a/app/controllers/calculation_result_controller.rb
+++ b/app/controllers/calculation_result_controller.rb
@@ -1,5 +1,12 @@
 # This controller handles all final results from the calculator - either full, none or partial
 class CalculationResultController < ApplicationController
   include CalculationStore
+  after_action :mark_as_complete
 
+  private
+
+  def mark_as_complete
+    current_calculation.freeze
+    repo.save current_calculation
+  end
 end

--- a/app/controllers/concerns/calculation_store.rb
+++ b/app/controllers/concerns/calculation_store.rb
@@ -19,6 +19,10 @@ module CalculationStore
     @current_calculation = nil
   end
 
+  def start_current_calculation
+    current_calculation.reset_messages
+  end
+
   def repo
     @repo ||= CalculationRepository.new(store: session)
   end

--- a/app/models/calculation.rb
+++ b/app/models/calculation.rb
@@ -2,7 +2,7 @@ class Calculation
   include ActiveModel::Model
   attr_accessor :available_help, :remission
   attr_accessor :messages
-  attr_accessor :final_decision_by
+  attr_accessor :final_decision_by, :frozen
   attr_reader :inputs
 
   def initialize(attrs = {})
@@ -11,7 +11,9 @@ class Calculation
     self.final_decision_by = :none
     self.remission = 0.0
     self.inputs = {}
+    self.frozen = false
     super
+    freeze_if_frozen
   end
 
   # Indicates if a calculator has made a final decision, preventing any further
@@ -30,5 +32,20 @@ class Calculation
 
   def merge_inputs(values)
     inputs.merge!(values)
+  end
+
+  # Removes all previous messages ready for a new calculation starting
+  def reset_messages
+    messages.clear
+  end
+
+  def freeze_if_frozen
+    freeze if frozen
+  end
+
+  def freeze
+    self.frozen = true
+    messages.freeze
+    super
   end
 end

--- a/app/services/calculation_service.rb
+++ b/app/services/calculation_service.rb
@@ -45,6 +45,7 @@ class CalculationService
   #  This is optional, normally for testing.
   # @return [CalculationService] This instance
   def initialize(inputs, calculation, calculators: default_calculators)
+    calculation.reset_messages
     self.inputs = inputs
     calculation.merge_inputs(inputs)
     self.calculation = calculation

--- a/spec/features/change_previous_answers_spec.rb
+++ b/spec/features/change_previous_answers_spec.rb
@@ -641,6 +641,30 @@ RSpec.describe 'Change previous answers test', type: :feature, js: true do
     # Assert
     expect(start_page).to be_displayed
   end
-  scenario 'Citizen who normally gets part remission tries to use the browser back button'
-  scenario 'Citizen who normally gets no remission tries to use the browser back button'
+
+  scenario 'Citizen who normally gets part remittance tries to use the browser back button' do
+    # Arrange - We will use oliver for this who would normally get partial remittance
+    given_i_am(:oliver)
+    answer_up_to(:total_income)
+    answer_total_income_question
+
+    # Act
+    partial_remission_page.back_via_browser_button
+
+    # Assert
+    expect(start_page).to be_displayed
+  end
+
+  scenario 'Citizen who normally gets no remittance tries to use the browser back button' do
+    # Arrange - We will use tony for this who would normally fail the disposable capital test
+    given_i_am(:oliver)
+    answer_up_to(:total_income)
+    answer_total_income_question
+
+    # Act
+    not_eligible_page.back_via_browser_button
+
+    # Assert
+    expect(start_page).to be_displayed
+  end
 end

--- a/spec/features/change_previous_answers_spec.rb
+++ b/spec/features/change_previous_answers_spec.rb
@@ -628,4 +628,19 @@ RSpec.describe 'Change previous answers test', type: :feature, js: true do
         and(have_total_income)
     end
   end
+
+  scenario 'Citizen who normally gets full remittance tries to use the browser back button' do
+    # Arrange - We will use john for this who would normally pass every test and get full remittance
+    given_i_am(:john)
+    answer_up_to(:total_income)
+    answer_total_income_question
+
+    # Act
+    full_remission_page.back_via_browser_button
+
+    # Assert
+    expect(start_page).to be_displayed
+  end
+  scenario 'Citizen who normally gets part remission tries to use the browser back button'
+  scenario 'Citizen who normally gets no remission tries to use the browser back button'
 end

--- a/spec/models/models/calculation_spec.rb
+++ b/spec/models/models/calculation_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe Calculation do
     end
   end
 
+  describe '#reset_messages' do
+    it 'clears out any old messages' do
+      subject = described_class.new messages: [:any]
+      subject.reset_messages
+      expect(subject.messages).to be_empty
+    end
+  end
+
   describe '#final_decision_by' do
     it 'stores a provided value of any type' do
       subject = described_class.new final_decision_by: 'none'
@@ -64,6 +72,32 @@ RSpec.describe Calculation do
       subject = described_class.new final_decision_by: :none
       expect(subject.final_decision_made?).to be false
     end
+  end
 
+  describe '#freeze' do
+    it 'freezes the messages array' do
+      subject = described_class.new messages: [:any]
+      subject.freeze
+
+      expect(subject.messages).to be_frozen
+    end
+  end
+
+  describe '#freeze_if_frozen' do
+    it 'freezes the object if the frozen attribute is true' do
+      subject = described_class.new
+      subject.frozen = true
+      subject.freeze_if_frozen
+
+      expect(subject).to be_frozen
+    end
+
+    it 'does not freezes the object if the frozen attribute is not true' do
+      subject = described_class.new
+      subject.frozen = false
+      subject.freeze_if_frozen
+
+      expect(subject).not_to be_frozen
+    end
   end
 end

--- a/test_common/page_objects/calculator/base_page.rb
+++ b/test_common/page_objects/calculator/base_page.rb
@@ -48,6 +48,10 @@ module Calculator
         previous_answers.send(q.to_sym).navigate_to
       end
 
+      def back_via_browser_button
+        page.evaluate_script('window.history.back()')
+      end
+
       # Finds a previous question with a given answer in the 'Previous answers' section of any pa
       # @param [Symbol] question The question to find
       # @param [Symbol,String,Array] answer Can be a string (the expected answer), a symbol (will get translated)


### PR DESCRIPTION
Fix for RST-919

Fixed issue where previous messages from the calculation were not being cleared before starting a new one.  This caused cookie overflow errors (the 'something went wrong' errors from RST-919)

Also now freezing the calculation on completion.  This freezing is done firstly to prevent modification by accident - and secondly, the controller detects it and redirects the user back to the start if the current calculation is frozen.

I have also added compression - the calculator instance is serialized then compressed before going into the session halving the size of the cookie.  It is only hitting around 600 bytes now - it was going to 2K before (the limit is 4K).