### PR TITLE
Feature/rst 921 - contribution rounding removal

### DIFF
--- a/features/step_definitions/total_income_steps.rb
+++ b/features/step_definitions/total_income_steps.rb
@@ -20,8 +20,8 @@ Then(/^I should see that I should be eligible for full remission$/) do
   expect(full_remission_page).to be_valid_for_final_positive_message(user)
 end
 
-Then(/^I should see that I should be eligible for part remission$/) do
-  expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 0)
+Then(/^I should see that I should be eligible for part remission where I need to pay (\d*)$/) do |citizen_pays|
+  expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: citizen_pays.to_i)
 end
 
 Then(/^I should see that I am not eligible for remission$/) do

--- a/features/total_income.feature
+++ b/features/total_income.feature
@@ -16,10 +16,10 @@ Scenario: Eligible for full remission
   Then I should see that I should be eligible for full remission
 
 Scenario: Eligible for part remission
-  Given I am Eden
+  Given I am Holly
   And I am on the total income page
   When I successfully submit my total income
-  Then I should see that I should be eligible for part remission
+  Then I should see that I should be eligible for part remission where I need to pay 2000
 
 Scenario: Not eligible for remission
   Given I am Joseph

--- a/spec/features/income_spec.rb
+++ b/spec/features/income_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 18240)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 1755)
   end
 
   # Scenario: Income test for single citizen with minimum income threshold (0 Remission)
@@ -205,7 +205,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 2900)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 1995)
   end
 
   # Scenario: Income test for single citizen with maximum income threshold
@@ -223,7 +223,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 4000)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 1995)
   end
 
   # Scenario: Income test for married citizen with maximum income threshold
@@ -241,7 +241,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 5000)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 1995)
   end
 
   # Scenario: Income test for single citizen with maximum income threshold
@@ -259,7 +259,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 4990)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 2000)
   end
 
   # Scenario: Income test for single citizen with maximum income threshold
@@ -277,7 +277,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 8000)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 2000)
   end
 
   # Scenario: Income test for single citizen over maximum income threshold
@@ -313,7 +313,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 940)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 1385)
   end
 
   # Scenario: Income test for single citizen with minimum income threshold and many children
@@ -373,6 +373,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
   #   AND I am on the total income page
   #   When I click on the Next step button
   #   Then I should see that I am eligible for partial remission
+  #   (CORRECTION: The original said partial remission, but RST-921 changed to no remission)
   #
   scenario 'Income test for married citizen with maximum income threshold and no children' do
     # Arrange
@@ -383,7 +384,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 0)
+    expect(not_eligible_page).to be_valid_for_final_negative_message(user)
   end
 
   # Scenario: Income test for single citizen with maximum income threshold and no children
@@ -391,6 +392,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
   #   AND I am on the total income page
   #   When I click on the Next step button
   #   Then I should see that I am eligible for partial remission
+  #   (CORRECTION: The original said partial remission, but RST-921 changed to no remission)
   #
   scenario 'Income test for single citizen with maximum income threshold and no children' do
     # Arrange
@@ -401,7 +403,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 0)
+    expect(not_eligible_page).to be_valid_for_final_negative_message(user)
   end
   # Scenario: Income test for married citizen with maximum income threshold and no children
   #   Given I am HOLLY (Married, 55, Capital 11999, Fee 6000, children 0, benefits none, income 5245 )
@@ -418,7 +420,7 @@ RSpec.describe 'Income Test', type: :feature, js: true do
     answer_total_income_question
 
     # Assert
-    expect(partial_remission_page).to be_valid_for_final_partial_message(user, remission: 4000)
+    expect(partial_remission_page).to be_valid_for_final_partial_message(user, citizen_pays: 2000)
   end
   # Scenario: Income test for single citizen with over maximum income threshold and no children
   #   Given I am THERESA

--- a/spec/services/household_income_calculator_service_spec.rb
+++ b/spec/services/household_income_calculator_service_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe HouseholdIncomeCalculatorService do
           expect(result).to have_attributes remission: fee
         end
 
-        it 'returns part remission of the full fee if monthly income is over the minimum by 10 pounds' do
+        it 'returns part remission of the full fee minus 5 pounds if monthly income is over the minimum by 10 pounds' do
           # Arrange
           income = minimum_threshold + 10.0
 
@@ -162,10 +162,10 @@ RSpec.describe HouseholdIncomeCalculatorService do
           result = service.call(marital_status: marital_status.to_s, total_income: income, number_of_children: children, fee: fee)
 
           # Assert
-          expect(result).to have_attributes remission: fee - 10.0
+          expect(result).to have_attributes remission: fee - 5.0
         end
 
-        it 'returns part remission of the full fee minus 30 pounds if monthly income is over the minimum by 50 pounds' do
+        it 'returns part remission of the full fee minus 25 pounds if monthly income is over the minimum by 50 pounds' do
           # Arrange
           income = minimum_threshold + 50.0
 
@@ -173,19 +173,7 @@ RSpec.describe HouseholdIncomeCalculatorService do
           result = service.call(marital_status: marital_status.to_s, total_income: income, number_of_children: children, fee: fee)
 
           # Assert
-          expect(result).to have_attributes remission: fee - 30
-        end
-
-        it 'returns zero if the remission would have gone negative' do
-          # Arrange - So that the user would have to pay more than the fee  according to the rules
-          fee = 1000.0
-          income = minimum_threshold + 2100.0
-
-          # Act
-          result = service.call(marital_status: marital_status.to_s, total_income: income, number_of_children: children, fee: fee)
-
-          # Assert
-          expect(result).to have_attributes remission: 0
+          expect(result).to have_attributes remission: fee - 25
         end
 
         it 'returns part remission if monthly income is over the minimum threshold and just below the maximum' do
@@ -259,6 +247,18 @@ RSpec.describe HouseholdIncomeCalculatorService do
         it 'returns no remission if monthly income is over the minimum threshold and above the maximum' do
           # Arrange
           income = maximum_threshold + 1.0
+
+          # Act
+          result = service.call(marital_status: marital_status.to_s, total_income: income, number_of_children: children, fee: fee)
+
+          # Assert
+          expect(result).to have_attributes available_help: :none
+        end
+
+        it 'returns zero if the remission would have gone negative' do
+          # Arrange - So that the user would have to pay more than the fee  according to the rules
+          fee = 1000.0
+          income = minimum_threshold + 2100.0
 
           # Act
           result = service.call(marital_status: marital_status.to_s, total_income: income, number_of_children: children, fee: fee)

--- a/test_common/page_objects/calculator/partial_remission_page.rb
+++ b/test_common/page_objects/calculator/partial_remission_page.rb
@@ -14,18 +14,18 @@ module Calculator
 
       # Verifies that the final partial remission message is present
       # @param [OpenStruct] user The user containing the fee and the monthly_gross_income
-      # @param [Fixnum] remission The expected remission as passed from the test suite
+      # @param [Fixnum] citizen_pays The expected amount the citizen must pay
       #
       # @return [Boolean] true if all OK
       # @raise [Capybara::ElementNotFound] If the correct message was not found
-      def valid_for_final_partial_message?(user, remission:)
+      def valid_for_final_partial_message?(user, citizen_pays:)
         marital_status = user.marital_status.downcase
         expected_header = messaging.translate "hwf_decision.partial.#{marital_status}.positive.heading"
         expected_detail = messaging.translate "hwf_decision.partial.#{marital_status}.positive.detail",
           fee: number_to_currency(user.fee, precision: 0, unit: '£'),
           total_income: number_to_currency(user.monthly_gross_income, precision: 0, unit: '£'),
-          remission: number_to_currency(remission, precision: 0, unit: '£'),
-          contribution: number_to_currency(user.fee - remission, precision: 0, unit: '£')
+          remission: number_to_currency(user.fee - citizen_pays, precision: 0, unit: '£'),
+          contribution: number_to_currency(citizen_pays, precision: 0, unit: '£')
 
         !!(feedback_message_with_header(expected_header) &&
             feedback_message_with_detail(expected_detail))

--- a/test_common/page_objects/calculator/partial_remission_page.rb
+++ b/test_common/page_objects/calculator/partial_remission_page.rb
@@ -19,16 +19,22 @@ module Calculator
       # @return [Boolean] true if all OK
       # @raise [Capybara::ElementNotFound] If the correct message was not found
       def valid_for_final_partial_message?(user, citizen_pays:)
+        !!(feedback_message_with_header(expected_header_for user) && feedback_message_with_detail(expected_detail_for user, citizen_pays))
+      end
+
+      private
+
+      def expected_header_for(user)
+        messaging.translate "hwf_decision.partial.#{user.marital_status}.positive.heading"
+      end
+
+      def expected_detail_for(user, citizen_pays)
         marital_status = user.marital_status.downcase
-        expected_header = messaging.translate "hwf_decision.partial.#{marital_status}.positive.heading"
-        expected_detail = messaging.translate "hwf_decision.partial.#{marital_status}.positive.detail",
+        messaging.translate "hwf_decision.partial.#{marital_status}.positive.detail",
           fee: number_to_currency(user.fee, precision: 0, unit: '£'),
           total_income: number_to_currency(user.monthly_gross_income, precision: 0, unit: '£'),
           remission: number_to_currency(user.fee - citizen_pays, precision: 0, unit: '£'),
           contribution: number_to_currency(citizen_pays, precision: 0, unit: '£')
-
-        !!(feedback_message_with_header(expected_header) &&
-            feedback_message_with_detail(expected_detail))
       end
     end
   end


### PR DESCRIPTION
RST-921 - This PR removes the extra rounding which was being done during the household income calculation - this is no longer required.
Also, the page that the user is sent to if their remission is zero (they have to pay the full fee) has been changed from the 'partial remission page' to the 'not eligible page' - as it wasnt right that they were being told they had partial help available, but the amount was zero.