### PR TITLE
RST-919 - Fixed back button issues

### DIFF
--- a/app/controllers/calculation_controller.rb
+++ b/app/controllers/calculation_controller.rb
@@ -3,7 +3,8 @@
 class CalculationController < ApplicationController
   include CalculationStore
   helper_method :form
-  before_action :start_again, if: :calculation_frozen?, except: :home
+  before_action :ensure_calculation_initialized, only: :update
+  before_action :start_again, unless: :calculation_state_valid?, except: :home
 
   def home
     repo.delete_all
@@ -65,11 +66,8 @@ class CalculationController < ApplicationController
       benefits_received: []
   end
 
-  def calculation_frozen?
-    current_calculation.frozen?
-  end
-
   def start_again
     redirect_to root_path
+    false
   end
 end

--- a/app/controllers/calculation_result_controller.rb
+++ b/app/controllers/calculation_result_controller.rb
@@ -1,6 +1,7 @@
 # This controller handles all final results from the calculator - either full, none or partial
 class CalculationResultController < ApplicationController
   include CalculationStore
+  before_action :start_again, unless: :calculation_state_valid?
   after_action :mark_as_complete
 
   private
@@ -8,5 +9,10 @@ class CalculationResultController < ApplicationController
   def mark_as_complete
     current_calculation.freeze
     repo.save current_calculation
+  end
+
+  def start_again
+    redirect_to root_path
+    false
   end
 end

--- a/app/controllers/concerns/calculation_store.rb
+++ b/app/controllers/concerns/calculation_store.rb
@@ -26,4 +26,12 @@ module CalculationStore
   def repo
     @repo ||= CalculationRepository.new(store: session)
   end
+
+  def calculation_state_valid?
+    current_calculation.state_valid?
+  end
+
+  def ensure_calculation_initialized
+    current_calculation.initialized = true
+  end
 end

--- a/app/models/calculation.rb
+++ b/app/models/calculation.rb
@@ -2,7 +2,7 @@ class Calculation
   include ActiveModel::Model
   attr_accessor :available_help, :remission
   attr_accessor :messages
-  attr_accessor :final_decision_by, :frozen
+  attr_accessor :final_decision_by, :frozen, :initialized
   attr_reader :inputs
 
   def initialize(attrs = {})
@@ -12,6 +12,7 @@ class Calculation
     self.remission = 0.0
     self.inputs = {}
     self.frozen = false
+    self.initialized = false
     super
     freeze_if_frozen
   end
@@ -41,6 +42,10 @@ class Calculation
 
   def freeze_if_frozen
     freeze if frozen
+  end
+
+  def state_valid?
+    initialized && !frozen
   end
 
   def freeze

--- a/spec/models/models/calculation_spec.rb
+++ b/spec/models/models/calculation_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Calculation do
                                          available_help: :undecided,
                                          messages: [],
                                          remission: 0.0,
-                                         final_decision_by: :none
+                                         final_decision_by: :none,
+                                         initialized: false
     end
   end
 
@@ -47,6 +48,15 @@ RSpec.describe Calculation do
     end
   end
 
+  describe '#initialized' do
+    it 'stores a provided value of any type' do
+      subject = described_class.new
+      subject.initialized = true
+
+      expect(subject.initialized).to be true
+    end
+  end
+
   describe '#reset_messages' do
     it 'clears out any old messages' do
       subject = described_class.new messages: [:any]
@@ -80,6 +90,30 @@ RSpec.describe Calculation do
       subject.freeze
 
       expect(subject.messages).to be_frozen
+    end
+  end
+
+  describe '#state_valid?' do
+    it 'is false if frozen' do
+      subject = described_class.new messages: [:any]
+      subject.initialized = true
+      subject.freeze
+
+      expect(subject.state_valid?).to be false
+    end
+
+    it 'is false if not initialized' do
+      subject = described_class.new messages: [:any]
+      subject.initialized = false
+
+      expect(subject.state_valid?).to be false
+    end
+
+    it 'is true if not frozen and initialized' do
+      subject = described_class.new messages: [:any]
+      subject.initialized = true
+
+      expect(subject.state_valid?).to be true
     end
   end
 


### PR DESCRIPTION
RST-919 - Now, the calculation is in an un initialized state before it is first updated.  Any attempts to fetch a question page whilst in this state will cause the flow to reset.  This means you can literally use the back button to go back to any page after a final result page and it will just restart.

This also prevents all the 'Invalid field' errors caused by the calculation being in an un initialized state