### PR TITLE
RST-926 - Fixed issue with alignment of pound sign for money input fields

### DIFF
--- a/app/assets/stylesheets/money-inputs.scss
+++ b/app/assets/stylesheets/money-inputs.scss
@@ -1,16 +1,19 @@
 .form-group {
   .form-control-money {
     position: relative;
-    input.form-control[type=text] {
-      padding-left: 1.2em;
+    input.form-control.money[type=text] {
+      padding-left: 1.5em;
     }
-  }
-  .form-control-money.gbp::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    content: "£";
-    margin: 0.5em 0.5em;
-
+    .currency {
+      width: 1em;
+      padding-left: 0px;
+      padding-right: 0px;
+      border-left: none;
+      border-right: none;
+      position: absolute;
+      left: 0.5em;
+      background-color: white;
+      color: black;
+    }
   }
 }

--- a/app/views/calculation/_disposable_capital.html.slim
+++ b/app/views/calculation/_disposable_capital.html.slim
@@ -9,6 +9,7 @@
         = gds_error_messages(model: f.object, method: :disposable_capital)
         label.block-label
           .form-control-money.gbp
+            input.form-control.currency type='text' value='£' disabled=true
             = f.text_field :disposable_capital, class: 'form-control'
         details.question_help data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.disposable_capital.summary')

--- a/app/views/calculation/_fee.html.slim
+++ b/app/views/calculation/_fee.html.slim
@@ -8,6 +8,7 @@
         = gds_error_messages(model: f.object, method: :fee)
         label.block-label
           .form-control-money.gbp
+            input.form-control.currency type='text' value='£' disabled=true
             = f.text_field :fee, class: 'form-control money gbp'
         details.question_help data-behavior="question_help"
           summary data-behavior="toggle" = t('calculation.guidance.fee.summary')

--- a/app/views/calculation/_total_income.html.slim
+++ b/app/views/calculation/_total_income.html.slim
@@ -9,6 +9,7 @@
         = gds_error_messages(model: f.object, method: :total_income)
         label.block-label
           .form-control-money.gbp
+            input.form-control.currency type='text' value='£' disabled=true
             = f.text_field :total_income, class: 'form-control'
         details.question_help data-behavior="question_help"
           summary data-behavior="toggle"= t('calculation.guidance.total_income.summary')


### PR DESCRIPTION
RST-926 - Fixed issue with alignment of pound sign for money input fields.

This PR changes the pound sign in front of every money field from a css 'content' value in a before:: selector to having its own input tag with the left and right borders set to none.  This is then positioned absolute so that it appears inside the original input element.  Tested on IE, Edge, Chrome and Safari