### PR TITLE
RST-919 Disabled caching on all question and final result pages

### DIFF
--- a/app/controllers/calculation_controller.rb
+++ b/app/controllers/calculation_controller.rb
@@ -2,9 +2,11 @@
 # manner.
 class CalculationController < ApplicationController
   include CalculationStore
+  include DisableCache
   helper_method :form
   before_action :ensure_calculation_initialized, only: :update
   before_action :start_again, unless: :calculation_state_valid?, except: :home
+  after_action :disable_cache, except: :home
 
   def home
     repo.delete_all

--- a/app/controllers/calculation_result_controller.rb
+++ b/app/controllers/calculation_result_controller.rb
@@ -1,8 +1,10 @@
 # This controller handles all final results from the calculator - either full, none or partial
 class CalculationResultController < ApplicationController
   include CalculationStore
+  include DisableCache
   before_action :start_again, unless: :calculation_state_valid?
   after_action :mark_as_complete
+  after_action :disable_cache
 
   private
 

--- a/app/controllers/concerns/disable_cache.rb
+++ b/app/controllers/concerns/disable_cache.rb
@@ -1,10 +1,6 @@
 module DisableCache
   extend ActiveSupport::Concern
 
-  included do |*args|
-    bl1 = 1
-  end
-
   private
 
   def disable_cache

--- a/app/controllers/concerns/disable_cache.rb
+++ b/app/controllers/concerns/disable_cache.rb
@@ -1,0 +1,15 @@
+module DisableCache
+  extend ActiveSupport::Concern
+
+  included do |*args|
+    bl1 = 1
+  end
+
+  private
+
+  def disable_cache
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
+end

--- a/spec/features/landing_page_content_spec.rb
+++ b/spec/features/landing_page_content_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe 'Landing page content', type: :feature, js: true do
     end
 
   end
+
+  scenario 'Verify caching is not disabled using NON JS BROWSER', js: false do
+    # Act
+    load_start_page
+
+    # Assert
+    expect(start_page).to have_cache
+  end
+
+
   #
   # Heading (Revised)
   #

--- a/spec/features/view_court_fees_content_spec.rb
+++ b/spec/features/view_court_fees_content_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe 'Court fees content', type: :feature, js: true do
       expect(court_fee_page.fee).to be_present
     end
   end
+
+  scenario 'Verify no caching on court fee question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:court_fee)
+
+    # Assert
+    expect(court_fee_page).to have_no_cache
+  end
+
   #
   #
   #

--- a/spec/features/view_date_of_birth_content_spec.rb
+++ b/spec/features/view_date_of_birth_content_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe 'View date of birth content', type: :feature, js: true do
     end
   end
 
+  scenario 'Verify no caching on date of birth question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:date_of_birth)
+
+    # Assert
+    expect(date_of_birth_page).to have_no_cache
+  end
+
   scenario 'View date of birth Heading, Question and Hint text for married couple' do
     # Arrange
     given_i_am(:alli)

--- a/spec/features/view_full_remission_page_spec.rb
+++ b/spec/features/view_full_remission_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+RSpec.describe 'View full remission page' do
+  scenario 'Verify no caching on full remission page using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+    answer_up_to(:total_income)
+
+    # Act
+    answer_total_income_question
+
+    # Assert
+    expect(full_remission_page).to have_no_cache
+  end
+end

--- a/spec/features/view_income_benefit_content_spec.rb
+++ b/spec/features/view_income_benefit_content_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe 'Partner status content', type: :feature, js: true do
     end
   end
 
+  scenario 'Verify no caching on income benefits question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:benefits)
+
+    # Assert
+    expect(income_benefits_page).to have_no_cache
+  end
+
   #
   #
   # Scenario: View Guidance Information

--- a/spec/features/view_not_eligible_page_spec.rb
+++ b/spec/features/view_not_eligible_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+RSpec.describe 'View not eligible page' do
+  scenario 'Verify no caching on not eligible page using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:joseph)
+    answer_up_to(:total_income)
+
+    # Act
+    answer_total_income_question
+
+    # Assert
+    expect(not_eligible_page).to have_no_cache
+  end
+end

--- a/spec/features/view_number_of_children_spec.rb
+++ b/spec/features/view_number_of_children_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe 'View number of children question content', type: :feature, js: t
       expect(number_of_children_page).to have_number_of_children_married
     end
   end
+
+  scenario 'Verify no caching on number of children question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:number_of_children)
+
+    # Assert
+    expect(number_of_children_page).to have_no_cache
+  end
+
   #
   # Scenario: View Guidance Information
   #              Given I am on the Number of Children page

--- a/spec/features/view_partial_remission_page_spec.rb
+++ b/spec/features/view_partial_remission_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+RSpec.describe 'View partial remission page' do
+  scenario 'Verify no caching on partial remission page using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:oliver)
+    answer_up_to(:total_income)
+
+    # Act
+    answer_total_income_question
+
+    # Assert
+    expect(partial_remission_page).to have_no_cache
+  end
+end

--- a/spec/features/view_partner_status_content_spec.rb
+++ b/spec/features/view_partner_status_content_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe 'Partner status content', type: :feature, js: true do
       expect(marital_status_page.marital_status).to be_present
     end
   end
+
+  scenario 'Verify no caching on partner status question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:marital_status)
+
+    # Assert
+    expect(marital_status_page).to have_no_cache
+  end
+
   #
   #
   #

--- a/spec/features/view_savings_and_investments_content_spec.rb
+++ b/spec/features/view_savings_and_investments_content_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe 'Savings and investments content', type: :feature, js: true do
     end
   end
 
+  scenario 'Verify no caching on savings and investments question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:disposable_capital)
+
+    # Assert
+    expect(disposable_capital_page).to have_no_cache
+  end
+
   #
   # Scenario: View Guidance Information
   #              Given I am on the Savings and investments page

--- a/spec/features/view_total_income_content_spec.rb
+++ b/spec/features/view_total_income_content_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe 'View total income content', type: :feature, js: true do
     end
   end
 
+  scenario 'Verify no caching on total income question using NON JS BROWSER', js: false do
+    # Arrange
+    given_i_am(:john)
+
+    # Act
+    answer_up_to(:total_income)
+
+    # Assert
+    expect(total_income_page).to have_no_cache
+  end
+
   #
   # Scenario: View Guidance Information
   #              Given I am on the Total Income page

--- a/test_common/helpers/setup.rb
+++ b/test_common/helpers/setup.rb
@@ -91,6 +91,10 @@ module Calculator
         return if user.income_benefits.nil?
         user.income_benefits.map!(&:to_sym)
       end
+
+      def all_questions
+        QUESTIONS - [:all]
+      end
     end
   end
 end


### PR DESCRIPTION
RST-919 Disabled caching on all question and final result pages

Internet explorer was using the cached version of the page when using the back button without bothering asking the backend.  Other browsers didnt do this.
This highlighted that we really need to disable cache as the question pages are not suitable for caching as they are constantly changing.

This PR disables cache on all question and final result pages