### PR TITLE
RST-1011 Replaced 'eg' with 'e.g.' on 2 pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,7 +204,7 @@ en:
               civil partners
               living together as if you are married or in a civil partnership
               living at the same address with a joint income
-              part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+              part of a couple forced to live apart, e.g. where one or both is serving in the Armed forces, in prison or living in residential care
       disposable_capital:
         summary: "Help with savings and investments"
         detail:
@@ -214,7 +214,7 @@ en:
               money in ISAs and any other savings accounts
               joint savings accounts that you share with your partner
               fixed rate or investment bonds
-              any lump sum (eg a redundancy payout)
+              any lump sum (e.g. a redundancy payout)
               stocks and shares
               trust funds (or any other kind of fund)
               capital value of additional property

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -177,7 +177,7 @@ en:
               civil partners
               living together as if you are married or in a civil partnership
               living at the same address with a joint income
-              part of a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+              part of a couple forced to live apart, e.g. where one or both is serving in the Armed forces, in prison or living in residential care
 
       buttons:
         next: 'Next'
@@ -214,7 +214,7 @@ en:
               money in ISAs and any other savings accounts
               joint savings accounts that you share with your partner
               fixed rate or investment bonds
-              any lump sum (eg a redundancy payout)
+              any lump sum (e.g. a redundancy payout)
               stocks and shares
               trust funds (or any other kind of fund)
               capital value of additional property


### PR DESCRIPTION
RST-1011 Replaced 'eg' with 'e.g.' on disposable capital page and found another on marital status page which was replaced