### PR TITLE
Bug fix - changing from married to single still kept the age as the oldest of the 2 rather than just the individual

### DIFF
--- a/app/models/field_collection.rb
+++ b/app/models/field_collection.rb
@@ -52,6 +52,18 @@ class FieldCollection
     fields[field].confirm if key?(field)
   end
 
+  def valid_only
+    clone.tap do |new_obj|
+      new_obj.fields.reject! { |_, field| field.invalidated }
+    end
+  end
+
+  def clone
+    super.tap do |o|
+      o.fields = o.fields.clone
+    end
+  end
+
   delegate :key?, :keys, :empty?, to: :fields
 
   private
@@ -68,6 +80,8 @@ class FieldCollection
   def value_for(key, value)
     Field.new(key, value)
   end
+
+  protected
 
   attr_accessor :fields
 end

--- a/app/services/calculation_service.rb
+++ b/app/services/calculation_service.rb
@@ -88,7 +88,7 @@ class CalculationService
   end
 
   def perform_calculation_using(calculator)
-    result = calculator.call(calculation.inputs)
+    result = calculator.call(calculation.inputs.valid_only)
     post_process_failure result, calculator
     post_process_undecided result, calculator
     post_process_success result, calculator

--- a/app/services/disposable_capital_calculator_service.rb
+++ b/app/services/disposable_capital_calculator_service.rb
@@ -54,7 +54,9 @@ class DisposableCapitalCalculatorService < BaseCalculatorService
   end
 
   def earliest_date_of_birth
-    [inputs[:date_of_birth], inputs[:partner_date_of_birth]].compact.min
+    candidates = [inputs[:date_of_birth]]
+    candidates << inputs[:partner_date_of_birth] unless inputs[:marital_status] == 'single'
+    candidates.compact.min
   end
 
   def process_inputs

--- a/spec/features/change_previous_answers_spec.rb
+++ b/spec/features/change_previous_answers_spec.rb
@@ -465,6 +465,23 @@ RSpec.describe 'Change previous answers test', type: :feature, js: true do
     end
   end
 
+  scenario 'Citizen who is under 61 but partner is over 61 changes their marital status from married to single from the total income page and ends up failing the disposable capital test' do
+    # Arrange - George is married and 60 but his partner is 80 so we can use him to get us to total income page
+    # then we will go back to marital status page
+    given_i_am(:george)
+    answer_up_to(:total_income)
+    total_income_page.previous_answers.marital_status.navigate_to
+
+    # Act
+    marital_status_page.marital_status.set(:single)
+    marital_status_page.next
+    disposable_capital_page.next
+
+    # Assert
+
+    expect(not_eligible_page).to be_displayed
+  end
+
   scenario 'Citizen changes their marital status from married to single from the total income page and ends up at number of children page after confirming disp capital and benefits' do
     # Arrange - Alli is married so we can use him to get us to total income page
     # then we will go back to marital status page

--- a/spec/models/models/field_collection_spec.rb
+++ b/spec/models/models/field_collection_spec.rb
@@ -103,4 +103,19 @@ RSpec.describe FieldCollection, type: :model do
       expect(collection.to_hash).not_to be field_values
     end
   end
+
+  describe '#valid_only' do
+    subject(:collection) { described_class.new(field_values) }
+
+    it 'provides a new instance with only valid inputs' do
+      collection.invalidate_field(:total_income)
+      new_collection = collection.valid_only
+
+      aggregate_failures 'check for new instance and valid inputs' do
+        expect(new_collection).not_to be collection
+        expect(new_collection.key?(:total_income)).to be false
+        expect(collection.key?(:total_income)).to be true
+      end
+    end
+  end
 end

--- a/spec/services/calculation_service_spec.rb
+++ b/spec/services/calculation_service_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe CalculationService do
         end
       end
 
+      it 'calls the calculators with only the non invalidated inputs' do
+        # Act
+        calculation.inputs.invalidate_field(:marital_status)
+        service.call(inputs, calculation, calculators: calculators)
+
+        # Assert
+        aggregate_failures 'validating all 3 calculator inputs' do
+          expect(calculator_1_class).to have_received(:call).with(an_object_having_attributes(to_hash: { disposable_capital: 1000.0 }))
+          expect(calculator_2_class).to have_received(:call).with(an_object_having_attributes(to_hash: { disposable_capital: 1000.0 }))
+          expect(calculator_3_class).to have_received(:call).with(an_object_having_attributes(to_hash: { disposable_capital: 1000.0 }))
+        end
+      end
+
       it 'returns an instance of CalculationService' do
         # Act and Assert
         expect(service.call(inputs, calculation, calculators: calculators)).to be_a described_class

--- a/spec/services/disposable_capital_calculator_service_spec.rb
+++ b/spec/services/disposable_capital_calculator_service_spec.rb
@@ -3,86 +3,90 @@ RSpec.describe DisposableCapitalCalculatorService do
   subject(:service) { described_class }
 
   describe '#call' do
-    shared_examples 'disposable_capital_limited_to' do |age:, partner_age: nil, fee:, limit:|
+    shared_examples 'disposable_capital_limited_to' do |age:, partner_age: nil, fee:, limit:, marital_status:|
       next_to_limit = limit - 1
 
-      context "age: #{age}, partner_age: #{partner_age}, fee: #{fee}" do
+      context "age: #{age}, partner_age: #{partner_age}, fee: #{fee}, marital_status: #{marital_status}" do
         date_of_birth = (age.years.ago - 1.day).to_date
         partner_date_of_birth = partner_age.nil? ? nil : (partner_age.years.ago - 1.day).to_date
         it "states help is available when disposable_capital: 0" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: 0)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: 0)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
         end
 
         it "states help is available when disposable_capital: 1" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: 1)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: 1)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
         end
 
         it "states help is available when disposable_capital: #{next_to_limit}" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: next_to_limit)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: next_to_limit)).to have_attributes available_help: :full, messages: a_collection_including(a_hash_including(key: :likely, source: :disposable_capital)), final_decision?: false
         end
 
         it "states help is not available when disposable_capital: #{limit}" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: limit)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: limit)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
         end
 
         it "states help is not available when disposable_capital: #{limit + 1}" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: limit + 1)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: limit + 1)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
         end
 
         it "states help is not available when disposable_capital: #{limit + 100000}" do
-          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, disposable_capital: limit + 100000)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
+          expect(service.call(date_of_birth: date_of_birth, partner_date_of_birth: partner_date_of_birth, fee: fee, marital_status: marital_status.to_s, disposable_capital: limit + 100000)).to have_attributes available_help: :none, messages: a_collection_including(a_hash_including(key: :final_negative, source: :disposable_capital)), final_decision?: true
         end
       end
     end
-    [[1, nil], [30, nil], [30, 30], [60, nil], [60, 60]].each do |(age, partner_age)|
+    [[1, nil, :single], [30, nil, :single], [30, 30, :sharing_income], [60, nil, :single], [60, 60, :sharing_income], [60, 62, :single]].each do |(age, partner_age, marital_status)|
       context "age: #{age}, partner_age: #{partner_age}" do
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1, limit: 3000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 500, limit: 3000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 999, limit: 3000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1000, limit: 3000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1001, limit: 4000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1334, limit: 4000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1335, limit: 4000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1336, limit: 5000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1500, limit: 5000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1664, limit: 5000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1665, limit: 5000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1666, limit: 6000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1800, limit: 6000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1999, limit: 6000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2000, limit: 6000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2001, limit: 7000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2150, limit: 7000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2329, limit: 7000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2330, limit: 7000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 2331, limit: 8000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 3000, limit: 8000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 3999, limit: 8000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 4000, limit: 8000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 4001, limit: 10000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 4500, limit: 10000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 4999, limit: 10000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 5000, limit: 10000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 5001, limit: 12000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 5500, limit: 12000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 5999, limit: 12000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 6000, limit: 12000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 6001, limit: 14000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 6500, limit: 14000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 6999, limit: 14000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 7000, limit: 14000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 7001, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 10000, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1000000000000, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1, limit: 3000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 500, limit: 3000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 999, limit: 3000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1000, limit: 3000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1001, limit: 4000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1334, limit: 4000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1335, limit: 4000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1336, limit: 5000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1500, limit: 5000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1664, limit: 5000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1665, limit: 5000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1666, limit: 6000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1800, limit: 6000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1999, limit: 6000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2000, limit: 6000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2001, limit: 7000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2150, limit: 7000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2329, limit: 7000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2330, limit: 7000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 2331, limit: 8000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 3000, limit: 8000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 3999, limit: 8000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 4000, limit: 8000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 4001, limit: 10000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 4500, limit: 10000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 4999, limit: 10000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 5000, limit: 10000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 5001, limit: 12000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 5500, limit: 12000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 5999, limit: 12000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 6000, limit: 12000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 6001, limit: 14000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 6500, limit: 14000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 6999, limit: 14000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 7000, limit: 14000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 7001, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 10000, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1000000000000, limit: 16000
       end
     end
-    [[61, nil], [62, nil], [99, nil], [60, 61], [61, 60], [59, 61], [61, 61], [61, 59], [62, 62], [61, 75]].each do |(age, partner_age)|
+    test_specs = [
+      [61, nil, :sharing_income], [62, nil, :sharing_income], [99, nil, :sharing_income], [60, 61, :sharing_income], [61, 60, :sharing_income], [59, 61, :sharing_income],
+      [61, 61, :sharing_income], [61, 59, :sharing_income], [62, 62, :sharing_income], [61, 75, :sharing_income]
+    ]
+    test_specs.each do |(age, partner_age, marital_status)|
       context "age #{age}, partner_age: #{partner_age}" do
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 10, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 100, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1000, limit: 16000
-        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, fee: 1000000000000, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 10, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 100, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1000, limit: 16000
+        include_examples 'disposable_capital_limited_to', age: age, partner_age: partner_age, marital_status: marital_status, fee: 1000000000000, limit: 16000
       end
     end
 

--- a/test_common/fixtures/personas.yml
+++ b/test_common/fixtures/personas.yml
@@ -323,6 +323,16 @@ william:
     - jobseekers_allowance
     - income_support
   monthly_gross_income: 0
+george:
+  marital_status: sharing_income
+  age: 60
+  partner_age: 80
+  disposable_capital: 15999
+  fee: 1000
+  number_of_children: 0
+  income_benefits:
+    - none
+  monthly_gross_income: 0
 
 
 


### PR DESCRIPTION
Calculation service now passes on 'valid_only' fields to the underlying calculators - meaning invalidated fields are shown to the user, but not used for calculation purposes.

Also, the partner date of birth is not used as part of age calculation if the marital status is single.  This is an edge case where the user has changed their marital status from married to single - but we dont want to delete the partner date of birth in case they did it by accident