### PR TITLE
Fix automated security tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ zap-passive-scan-report:
 	# Generate the HTML report
 	docker exec $(call container-id-for,calculator,zap) zap-cli -p 8095 report -f html -o /tmp/zap-passive-scan-results.html
 	# Get the report
-	docker cp $(call container-id-for,calculator,zap):/tmp/zap-passive-scan-results.html /tmp
-	@echo "Open /tmp/zap-passive-scan-results.html in your browser"
+	docker cp $(call container-id-for,calculator,zap):/tmp/zap-passive-scan-results.html ./tmp
+	@echo "Open ./tmp/zap-passive-scan-results.html in your browser"

--- a/docker/tests/docker-compose.yml
+++ b/docker/tests/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       ZAP_HOST: http://zap:8095
       CAPYBARA_SERVER_HOST: security-tests
+      CAPYBARA_SERVER_PORT: '3000'
+      CAPYBARA_APP_HOST: http://security-tests:3000
     command: ./docker/tests/run_security_tests.sh
     links:
       - zap

--- a/docker/tests/run_security_tests.sh
+++ b/docker/tests/run_security_tests.sh
@@ -1,7 +1,6 @@
 #! /bin/bash
 set -e
 
-ZAP_HOST=${ZAP_HOST:-http://0.0.0.0:8095/}
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $ZAP_HOST)" != "200" ]]; do
   >&2 echo "Waiting for ZAP to start"
   sleep 2

--- a/test_common/capybara/capybara_driver_helper.rb
+++ b/test_common/capybara/capybara_driver_helper.rb
@@ -43,6 +43,7 @@ Capybara.register_driver :zap do |app|
   options.add_argument('--no-sandbox')
   options.add_argument('--headless')
   options.add_argument("--proxy-server=#{zap_url}")
+  options.add_argument('--window-size=1920,1080')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 

--- a/test_common/page_objects.rb
+++ b/test_common/page_objects.rb
@@ -1,4 +1,5 @@
 require_relative 'capybara_selectors'
 require_relative 'sections'
 require_relative 'page_objects/calculator/base_page'
+require_relative 'page_objects/calculator/base_popup_page'
 Dir.glob(File.absolute_path('../page_objects/**/*.rb', __FILE__)).each { |f| require f }


### PR DESCRIPTION
This PR includes some bug fixes and some minor changes related to the security tests automation.

Most notable:
- `base_popup_page.rb` will be required before other tests try to use it
- set the necessary Capybara env variables required to run the security tests in docker